### PR TITLE
Combined dependency updates (2024-03-10)

### DIFF
--- a/dashgit-updater/pom.xml
+++ b/dashgit-updater/pom.xml
@@ -93,7 +93,7 @@
 		<dependency>
 			<groupId>org.eclipse.jgit</groupId>
 			<artifactId>org.eclipse.jgit</artifactId>
-			<version>6.8.0.202311291450-r</version>
+			<version>6.9.0.202403050737-r</version>
 		</dependency>
 
 	</dependencies>

--- a/dashgit-updater/pom.xml
+++ b/dashgit-updater/pom.xml
@@ -83,7 +83,7 @@
 		<dependency>
 			<groupId>org.kohsuke</groupId>
 			<artifactId>github-api</artifactId>
-			<version>1.318</version>
+			<version>1.319</version>
 		</dependency>
 		<dependency>
 			<groupId>org.gitlab4j</groupId>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump org.kohsuke:github-api from 1.318 to 1.319 in /dashgit-updater](https://github.com/javiertuya/dashgit/pull/29)
- [Bump org.eclipse.jgit:org.eclipse.jgit from 6.8.0.202311291450-r to 6.9.0.202403050737-r in /dashgit-updater](https://github.com/javiertuya/dashgit/pull/28)