### PR TITLE
Combined dependency updates (2024-04-01)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,4 +40,4 @@ jobs:
           path: 'dashgit-web/dist'
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4.0.4
+        uses: actions/deploy-pages@v4.0.5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v5
 
       - name: Prepare release
         working-directory: dashgit-web

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,7 +91,7 @@ jobs:
       output1: ${{ steps.filter.outputs.workflows }}
     if: (github.event_name != 'pull_request' && ! github.event.pull_request.head.repo.fork) || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.fork || startsWith(github.head_ref, 'dependabot/')))
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - run: echo "current branch ${{ github.ref_name }}"
     - uses: dorny/paths-filter@v3.0.2
       id: filter

--- a/dashgit-updater/pom.xml
+++ b/dashgit-updater/pom.xml
@@ -83,7 +83,7 @@
 		<dependency>
 			<groupId>org.kohsuke</groupId>
 			<artifactId>github-api</artifactId>
-			<version>1.319</version>
+			<version>1.321</version>
 		</dependency>
 		<dependency>
 			<groupId>org.gitlab4j</groupId>

--- a/dashgit-updater/pom.xml
+++ b/dashgit-updater/pom.xml
@@ -66,7 +66,7 @@
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-slf4j2-impl</artifactId>
-			<version>2.23.0</version>
+			<version>2.23.1</version>
 		</dependency>
 
 		<dependency>

--- a/dashgit-updater/pom.xml
+++ b/dashgit-updater/pom.xml
@@ -55,7 +55,7 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<version>1.18.30</version>
+			<version>1.18.32</version>
 		</dependency>
 
 		<dependency>

--- a/dashgit-updater/pom.xml
+++ b/dashgit-updater/pom.xml
@@ -72,7 +72,7 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-web</artifactId>
-			<version>6.1.4</version>
+			<version>6.1.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.httpcomponents.client5</groupId>

--- a/dashgit-web/test/package.json
+++ b/dashgit-web/test/package.json
@@ -8,7 +8,7 @@
     "report": "mocha Test*.js --reporter mochawesome"
   },
   "dependencies": {
-    "mocha": "10.3.0",
+    "mocha": "10.4.0",
 
     "chai": "5.1.0",
     


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump org.apache.logging.log4j:log4j-slf4j2-impl from 2.23.0 to 2.23.1 in /dashgit-updater](https://github.com/javiertuya/dashgit/pull/53)
- [Bump org.kohsuke:github-api from 1.319 to 1.321 in /dashgit-updater](https://github.com/javiertuya/dashgit/pull/52)
- [Bump org.projectlombok:lombok from 1.18.30 to 1.18.32 in /dashgit-updater](https://github.com/javiertuya/dashgit/pull/51)
- [Bump org.springframework:spring-web from 6.1.4 to 6.1.5 in /dashgit-updater](https://github.com/javiertuya/dashgit/pull/50)
- [Bump actions/deploy-pages from 4.0.4 to 4.0.5](https://github.com/javiertuya/dashgit/pull/49)
- [Bump mocha from 10.3.0 to 10.4.0 in /dashgit-web/test](https://github.com/javiertuya/dashgit/pull/48)
- [Bump actions/checkout from 3 to 4](https://github.com/javiertuya/dashgit/pull/47)
- [Bump actions/configure-pages from 4 to 5](https://github.com/javiertuya/dashgit/pull/46)