### PR TITLE
Combined dependency updates (2024-06-01)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -158,7 +158,7 @@ jobs:
 
       - name: Generate report checks - ${{ matrix.scope }}
         if: success() || failure()
-        uses: mikepenz/action-junit-report@v4.2.1
+        uses: mikepenz/action-junit-report@v4.2.2
         with:
           check_name: "test-it-result-${{ matrix.scope }}"
           report_paths: "**/surefire-reports/TEST-*.xml"

--- a/dashgit-updater/pom.xml
+++ b/dashgit-updater/pom.xml
@@ -88,7 +88,7 @@
 		<dependency>
 			<groupId>org.gitlab4j</groupId>
 			<artifactId>gitlab4j-api</artifactId>
-			<version>5.5.0</version>
+			<version>5.6.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.jgit</groupId>

--- a/dashgit-updater/pom.xml
+++ b/dashgit-updater/pom.xml
@@ -72,7 +72,7 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-web</artifactId>
-			<version>6.1.6</version>
+			<version>6.1.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.httpcomponents.client5</groupId>

--- a/dashgit-web/app/package.json
+++ b/dashgit-web/app/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "dependencies": {
-    "@octokit/rest": "20.1.0",
+    "@octokit/rest": "20.1.1",
     "@octokit/graphql": "8.1.1",
     "@gitbeaker/rest": "40.0.3"
   }

--- a/dashgit-web/test/package.json
+++ b/dashgit-web/test/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "mocha": "10.4.0",
-    "chai": "5.1.0",
+    "chai": "5.1.1",
     "mochawesome": "7.1.3"
   }
 }


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump org.gitlab4j:gitlab4j-api from 5.5.0 to 5.6.0 in /dashgit-updater](https://github.com/javiertuya/dashgit/pull/69)
- [Bump @octokit/rest from 20.1.0 to 20.1.1 in /dashgit-web/app in the web-manual-updates group](https://github.com/javiertuya/dashgit/pull/68)
- [Bump org.springframework:spring-web from 6.1.6 to 6.1.8 in /dashgit-updater](https://github.com/javiertuya/dashgit/pull/67)
- [Bump mikepenz/action-junit-report from 4.2.1 to 4.2.2](https://github.com/javiertuya/dashgit/pull/66)
- [Bump chai from 5.1.0 to 5.1.1 in /dashgit-web/test](https://github.com/javiertuya/dashgit/pull/65)