### PR TITLE
Combined dependency updates (2024-07-03)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,7 @@ jobs:
       - if: github.event.pull_request.head.repo.fork
         name: Failing job that is executed from forked repo
         run: exit 1
-      - uses: javiertuya/sonarqube-action@v1.3.1
+      - uses: javiertuya/sonarqube-action@v1.3.2
         with: 
           github-token: ${{ secrets.GITHUB_TOKEN }}
           sonar-token: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -158,7 +158,7 @@ jobs:
 
       - name: Generate report checks - ${{ matrix.scope }}
         if: success() || failure()
-        uses: mikepenz/action-junit-report@v4.2.2
+        uses: mikepenz/action-junit-report@v4.3.1
         with:
           check_name: "test-it-result-${{ matrix.scope }}"
           report_paths: "**/surefire-reports/TEST-*.xml"

--- a/dashgit-updater/pom.xml
+++ b/dashgit-updater/pom.xml
@@ -72,7 +72,7 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-web</artifactId>
-			<version>6.1.8</version>
+			<version>6.1.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.httpcomponents.client5</groupId>

--- a/dashgit-updater/pom.xml
+++ b/dashgit-updater/pom.xml
@@ -93,7 +93,7 @@
 		<dependency>
 			<groupId>org.eclipse.jgit</groupId>
 			<artifactId>org.eclipse.jgit</artifactId>
-			<version>6.9.0.202403050737-r</version>
+			<version>6.10.0.202406032230-r</version>
 		</dependency>
 
 	</dependencies>

--- a/dashgit-updater/pom.xml
+++ b/dashgit-updater/pom.xml
@@ -55,7 +55,7 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<version>1.18.32</version>
+			<version>1.18.34</version>
 		</dependency>
 
 		<dependency>

--- a/dashgit-updater/pom.xml
+++ b/dashgit-updater/pom.xml
@@ -37,7 +37,7 @@
 		<dependency>
 			<groupId>io.github.javiertuya</groupId>
 			<artifactId>portable-java</artifactId>
-			<version>2.2.1</version>
+			<version>2.2.3</version>
 		</dependency>
 		<dependency>
 			<groupId>io.github.javiertuya</groupId>

--- a/dashgit-updater/pom.xml
+++ b/dashgit-updater/pom.xml
@@ -42,7 +42,7 @@
 		<dependency>
 			<groupId>io.github.javiertuya</groupId>
 			<artifactId>visual-assert</artifactId>
-			<version>2.4.1</version>
+			<version>2.4.2</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/dashgit-updater/pom.xml
+++ b/dashgit-updater/pom.xml
@@ -83,7 +83,7 @@
 		<dependency>
 			<groupId>org.kohsuke</groupId>
 			<artifactId>github-api</artifactId>
-			<version>1.321</version>
+			<version>1.323</version>
 		</dependency>
 		<dependency>
 			<groupId>org.gitlab4j</groupId>

--- a/dashgit-web/app/package.json
+++ b/dashgit-web/app/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "dependencies": {
-    "@octokit/rest": "20.1.1",
+    "@octokit/rest": "21.0.0",
     "@octokit/graphql": "8.1.1",
     "@gitbeaker/rest": "40.0.3"
   }

--- a/dashgit-web/test/package.json
+++ b/dashgit-web/test/package.json
@@ -8,7 +8,7 @@
     "report": "mocha Test*.js --reporter mochawesome"
   },
   "dependencies": {
-    "mocha": "10.4.0",
+    "mocha": "10.5.2",
     "chai": "5.1.1",
     "mochawesome": "7.1.3"
   }


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump javiertuya/sonarqube-action from 1.3.1 to 1.3.2](https://github.com/javiertuya/dashgit/pull/80)
- [Bump mikepenz/action-junit-report from 4.2.2 to 4.3.1](https://github.com/javiertuya/dashgit/pull/79)
- [Bump mocha from 10.4.0 to 10.5.2 in /dashgit-web/test](https://github.com/javiertuya/dashgit/pull/78)
- [Bump io.github.javiertuya:visual-assert from 2.4.1 to 2.4.2 in /dashgit-updater](https://github.com/javiertuya/dashgit/pull/77)
- [Bump org.springframework:spring-web from 6.1.8 to 6.1.10 in /dashgit-updater](https://github.com/javiertuya/dashgit/pull/76)
- [Bump org.eclipse.jgit:org.eclipse.jgit from 6.9.0.202403050737-r to 6.10.0.202406032230-r in /dashgit-updater](https://github.com/javiertuya/dashgit/pull/75)
- [Bump org.projectlombok:lombok from 1.18.32 to 1.18.34 in /dashgit-updater](https://github.com/javiertuya/dashgit/pull/74)
- [Bump io.github.javiertuya:portable-java from 2.2.1 to 2.2.3 in /dashgit-updater](https://github.com/javiertuya/dashgit/pull/73)
- [Bump org.kohsuke:github-api from 1.321 to 1.323 in /dashgit-updater](https://github.com/javiertuya/dashgit/pull/72)
- [Bump @octokit/rest from 20.1.1 to 21.0.0 in /dashgit-web/app in the web-manual-updates group](https://github.com/javiertuya/dashgit/pull/71)