### PR TITLE
Combined dependency updates (2024-09-02)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
           npm run report
       - name: Publish test report files
         if: success() || failure() # always run even if the previous step fails
-        uses: actions/upload-artifact@v4.3.4
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: "test-ut-report-files"
           path: |
@@ -169,7 +169,7 @@ jobs:
       - if: success()
         run: echo "true" > test-it-status-${{ matrix.scope }}.txt
 
-      - uses: actions/upload-artifact@v4.3.4
+      - uses: actions/upload-artifact@v4.4.0
         if: success() || failure()
         with:
           name: test-it-status-${{ matrix.scope }}

--- a/dashgit-updater/pom.xml
+++ b/dashgit-updater/pom.xml
@@ -37,7 +37,7 @@
 		<dependency>
 			<groupId>io.github.javiertuya</groupId>
 			<artifactId>portable-java</artifactId>
-			<version>2.2.3</version>
+			<version>2.3.0</version>
 		</dependency>
 		<dependency>
 			<groupId>io.github.javiertuya</groupId>

--- a/dashgit-updater/pom.xml
+++ b/dashgit-updater/pom.xml
@@ -83,7 +83,7 @@
 		<dependency>
 			<groupId>org.kohsuke</groupId>
 			<artifactId>github-api</artifactId>
-			<version>1.323</version>
+			<version>1.324</version>
 		</dependency>
 		<dependency>
 			<groupId>org.gitlab4j</groupId>

--- a/dashgit-updater/pom.xml
+++ b/dashgit-updater/pom.xml
@@ -72,7 +72,7 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-web</artifactId>
-			<version>6.1.11</version>
+			<version>6.1.12</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.httpcomponents.client5</groupId>

--- a/dashgit-updater/pom.xml
+++ b/dashgit-updater/pom.xml
@@ -42,7 +42,7 @@
 		<dependency>
 			<groupId>io.github.javiertuya</groupId>
 			<artifactId>visual-assert</artifactId>
-			<version>2.4.2</version>
+			<version>2.5.0</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/dashgit-updater/pom.xml
+++ b/dashgit-updater/pom.xml
@@ -61,7 +61,7 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>2.0.13</version>
+			<version>2.0.16</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>

--- a/dashgit-web/app/package.json
+++ b/dashgit-web/app/package.json
@@ -1,8 +1,8 @@
 {
   "type": "module",
   "dependencies": {
-    "@octokit/rest": "21.0.1",
+    "@octokit/rest": "21.0.2",
     "@octokit/graphql": "8.1.1",
-    "@gitbeaker/rest": "40.1.2"
+    "@gitbeaker/rest": "40.1.3"
   }
 }

--- a/dashgit-web/test/package.json
+++ b/dashgit-web/test/package.json
@@ -8,7 +8,7 @@
     "report": "mocha Test*.js --reporter mochawesome"
   },
   "dependencies": {
-    "mocha": "10.7.0",
+    "mocha": "10.7.3",
     "chai": "5.1.1",
     "mochawesome": "7.1.3"
   }


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump org.slf4j:slf4j-api from 2.0.13 to 2.0.16 in /dashgit-updater](https://github.com/javiertuya/dashgit/pull/96)
- [Bump io.github.javiertuya:portable-java from 2.2.3 to 2.3.0 in /dashgit-updater](https://github.com/javiertuya/dashgit/pull/95)
- [Bump org.kohsuke:github-api from 1.323 to 1.324 in /dashgit-updater](https://github.com/javiertuya/dashgit/pull/94)
- [Bump org.springframework:spring-web from 6.1.11 to 6.1.12 in /dashgit-updater](https://github.com/javiertuya/dashgit/pull/93)
- [Bump io.github.javiertuya:visual-assert from 2.4.2 to 2.5.0 in /dashgit-updater](https://github.com/javiertuya/dashgit/pull/92)
- [Bump mocha from 10.7.0 to 10.7.3 in /dashgit-web/test](https://github.com/javiertuya/dashgit/pull/91)
- [Bump the web-manual-updates group in /dashgit-web/app with 2 updates](https://github.com/javiertuya/dashgit/pull/90)
- [Bump actions/upload-artifact from 4.3.4 to 4.4.0](https://github.com/javiertuya/dashgit/pull/89)