### PR TITLE
Combined dependency updates (2024-10-02)

### DIFF
--- a/dashgit-updater/pom.xml
+++ b/dashgit-updater/pom.xml
@@ -66,7 +66,7 @@
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-slf4j2-impl</artifactId>
-			<version>2.23.1</version>
+			<version>2.24.1</version>
 		</dependency>
 
 		<dependency>

--- a/dashgit-updater/pom.xml
+++ b/dashgit-updater/pom.xml
@@ -83,7 +83,7 @@
 		<dependency>
 			<groupId>org.kohsuke</groupId>
 			<artifactId>github-api</artifactId>
-			<version>1.324</version>
+			<version>1.326</version>
 		</dependency>
 		<dependency>
 			<groupId>org.gitlab4j</groupId>

--- a/dashgit-updater/pom.xml
+++ b/dashgit-updater/pom.xml
@@ -72,7 +72,7 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-web</artifactId>
-			<version>6.1.12</version>
+			<version>6.1.13</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.httpcomponents.client5</groupId>

--- a/dashgit-updater/pom.xml
+++ b/dashgit-updater/pom.xml
@@ -93,7 +93,7 @@
 		<dependency>
 			<groupId>org.eclipse.jgit</groupId>
 			<artifactId>org.eclipse.jgit</artifactId>
-			<version>6.10.0.202406032230-r</version>
+			<version>7.0.0.202409031743-r</version>
 		</dependency>
 
 	</dependencies>

--- a/dashgit-updater/pom.xml
+++ b/dashgit-updater/pom.xml
@@ -77,7 +77,7 @@
 		<dependency>
 			<groupId>org.apache.httpcomponents.client5</groupId>
 			<artifactId>httpclient5</artifactId>
-			<version>5.3.1</version>
+			<version>5.4</version>
 		</dependency>
 
 		<dependency>

--- a/dashgit-web/app/package.json
+++ b/dashgit-web/app/package.json
@@ -3,6 +3,6 @@
   "dependencies": {
     "@octokit/rest": "21.0.2",
     "@octokit/graphql": "8.1.1",
-    "@gitbeaker/rest": "40.1.3"
+    "@gitbeaker/rest": "40.3.0"
   }
 }


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump @gitbeaker/rest from 40.1.3 to 40.3.0 in /dashgit-web/app in the web-manual-updates group](https://github.com/javiertuya/dashgit/pull/103)
- [Bump org.apache.httpcomponents.client5:httpclient5 from 5.3.1 to 5.4 in /dashgit-updater](https://github.com/javiertuya/dashgit/pull/102)
- [Bump org.apache.logging.log4j:log4j-slf4j2-impl from 2.23.1 to 2.24.1 in /dashgit-updater](https://github.com/javiertuya/dashgit/pull/101)
- [Bump org.kohsuke:github-api from 1.324 to 1.326 in /dashgit-updater](https://github.com/javiertuya/dashgit/pull/100)
- [Bump org.springframework:spring-web from 6.1.12 to 6.1.13 in /dashgit-updater](https://github.com/javiertuya/dashgit/pull/99)
- [Bump org.eclipse.jgit:org.eclipse.jgit from 6.10.0.202406032230-r to 7.0.0.202409031743-r in /dashgit-updater](https://github.com/javiertuya/dashgit/pull/98)