### PR TITLE
Combined dependency updates (2024-11-02)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
           npm run report
       - name: Publish test report files
         if: success() || failure() # always run even if the previous step fails
-        uses: actions/upload-artifact@v4.4.0
+        uses: actions/upload-artifact@v4.4.3
         with:
           name: "test-ut-report-files"
           path: |
@@ -169,7 +169,7 @@ jobs:
       - if: success()
         run: echo "true" > test-it-status-${{ matrix.scope }}.txt
 
-      - uses: actions/upload-artifact@v4.4.0
+      - uses: actions/upload-artifact@v4.4.3
         if: success() || failure()
         with:
           name: test-it-status-${{ matrix.scope }}

--- a/dashgit-updater/pom.xml
+++ b/dashgit-updater/pom.xml
@@ -77,7 +77,7 @@
 		<dependency>
 			<groupId>org.apache.httpcomponents.client5</groupId>
 			<artifactId>httpclient5</artifactId>
-			<version>5.4</version>
+			<version>5.4.1</version>
 		</dependency>
 
 		<dependency>

--- a/dashgit-updater/pom.xml
+++ b/dashgit-updater/pom.xml
@@ -88,7 +88,7 @@
 		<dependency>
 			<groupId>org.gitlab4j</groupId>
 			<artifactId>gitlab4j-api</artifactId>
-			<version>5.6.0</version>
+			<version>5.7.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.jgit</groupId>

--- a/dashgit-updater/pom.xml
+++ b/dashgit-updater/pom.xml
@@ -42,7 +42,7 @@
 		<dependency>
 			<groupId>io.github.javiertuya</groupId>
 			<artifactId>visual-assert</artifactId>
-			<version>2.5.0</version>
+			<version>2.5.1</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/dashgit-updater/pom.xml
+++ b/dashgit-updater/pom.xml
@@ -72,7 +72,7 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-web</artifactId>
-			<version>6.1.13</version>
+			<version>6.1.14</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.httpcomponents.client5</groupId>

--- a/dashgit-web/app/package.json
+++ b/dashgit-web/app/package.json
@@ -3,6 +3,6 @@
   "dependencies": {
     "@octokit/rest": "21.0.2",
     "@octokit/graphql": "8.1.1",
-    "@gitbeaker/rest": "40.3.0"
+    "@gitbeaker/rest": "41.1.0"
   }
 }

--- a/dashgit-web/test/package.json
+++ b/dashgit-web/test/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "mocha": "10.7.3",
-    "chai": "5.1.1",
+    "chai": "5.1.2",
     "mochawesome": "7.1.3"
   }
 }

--- a/dashgit-web/test/package.json
+++ b/dashgit-web/test/package.json
@@ -8,7 +8,7 @@
     "report": "mocha Test*.js --reporter mochawesome"
   },
   "dependencies": {
-    "mocha": "10.7.3",
+    "mocha": "10.8.2",
     "chai": "5.1.2",
     "mochawesome": "7.1.3"
   }


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump actions/upload-artifact from 4.4.0 to 4.4.3](https://github.com/javiertuya/dashgit/pull/114)
- [Bump chai from 5.1.1 to 5.1.2 in /dashgit-web/test](https://github.com/javiertuya/dashgit/pull/113)
- [Bump mocha from 10.7.3 to 10.8.2 in /dashgit-web/test](https://github.com/javiertuya/dashgit/pull/112)
- [Bump org.apache.httpcomponents.client5:httpclient5 from 5.4 to 5.4.1 in /dashgit-updater](https://github.com/javiertuya/dashgit/pull/111)
- [Bump org.springframework:spring-web from 6.1.13 to 6.1.14 in /dashgit-updater](https://github.com/javiertuya/dashgit/pull/110)
- [Bump io.github.javiertuya:visual-assert from 2.5.0 to 2.5.1 in /dashgit-updater](https://github.com/javiertuya/dashgit/pull/109)
- [Bump org.gitlab4j:gitlab4j-api from 5.6.0 to 5.7.0 in /dashgit-updater](https://github.com/javiertuya/dashgit/pull/108)
- [Bump @gitbeaker/rest from 40.3.0 to 41.1.0 in /dashgit-web/app in the web-manual-updates group](https://github.com/javiertuya/dashgit/pull/107)