### PR TITLE
Combined dependency updates (2024-12-03)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -158,7 +158,7 @@ jobs:
 
       - name: Generate report checks - ${{ matrix.scope }}
         if: success() || failure()
-        uses: mikepenz/action-junit-report@v4.3.1
+        uses: mikepenz/action-junit-report@v5.1.0
         with:
           check_name: "test-it-result-${{ matrix.scope }}"
           report_paths: "**/surefire-reports/TEST-*.xml"

--- a/dashgit-updater/pom.xml
+++ b/dashgit-updater/pom.xml
@@ -55,7 +55,7 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<version>1.18.34</version>
+			<version>1.18.36</version>
 		</dependency>
 
 		<dependency>

--- a/dashgit-updater/pom.xml
+++ b/dashgit-updater/pom.xml
@@ -72,7 +72,7 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-web</artifactId>
-			<version>6.1.14</version>
+			<version>6.2.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.httpcomponents.client5</groupId>

--- a/dashgit-updater/pom.xml
+++ b/dashgit-updater/pom.xml
@@ -88,7 +88,7 @@
 		<dependency>
 			<groupId>org.gitlab4j</groupId>
 			<artifactId>gitlab4j-api</artifactId>
-			<version>5.8.0</version>
+			<version>5.7.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.jgit</groupId>

--- a/dashgit-updater/pom.xml
+++ b/dashgit-updater/pom.xml
@@ -66,7 +66,7 @@
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-slf4j2-impl</artifactId>
-			<version>2.24.1</version>
+			<version>2.24.2</version>
 		</dependency>
 
 		<dependency>

--- a/dashgit-updater/pom.xml
+++ b/dashgit-updater/pom.xml
@@ -88,7 +88,7 @@
 		<dependency>
 			<groupId>org.gitlab4j</groupId>
 			<artifactId>gitlab4j-api</artifactId>
-			<version>5.7.0</version>
+			<version>5.8.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.jgit</groupId>

--- a/dashgit-web/app/package.json
+++ b/dashgit-web/app/package.json
@@ -3,6 +3,6 @@
   "dependencies": {
     "@octokit/rest": "21.0.2",
     "@octokit/graphql": "8.1.1",
-    "@gitbeaker/rest": "41.1.0"
+    "@gitbeaker/rest": "41.3.0"
   }
 }


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump org.springframework:spring-web from 6.1.14 to 6.2.0 in /dashgit-updater](https://github.com/javiertuya/dashgit/pull/126)
- [Bump org.apache.logging.log4j:log4j-slf4j2-impl from 2.24.1 to 2.24.2 in /dashgit-updater](https://github.com/javiertuya/dashgit/pull/125)
- [Bump org.gitlab4j:gitlab4j-api from 5.7.0 to 5.8.0 in /dashgit-updater](https://github.com/javiertuya/dashgit/pull/124) REVERTED
- [Bump org.projectlombok:lombok from 1.18.34 to 1.18.36 in /dashgit-updater](https://github.com/javiertuya/dashgit/pull/123)
- [Bump mikepenz/action-junit-report from 4.3.1 to 5.1.0](https://github.com/javiertuya/dashgit/pull/122)
- [Bump @gitbeaker/rest from 41.1.0 to 41.3.0 in /dashgit-web/app in the web-manual-updates group](https://github.com/javiertuya/dashgit/pull/121)