### PR TITLE
Combined dependency updates (2025-01-11)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -158,7 +158,7 @@ jobs:
 
       - name: Generate report checks - ${{ matrix.scope }}
         if: success() || failure()
-        uses: mikepenz/action-junit-report@v5.1.0
+        uses: mikepenz/action-junit-report@v5.2.0
         with:
           check_name: "test-it-result-${{ matrix.scope }}"
           report_paths: "**/surefire-reports/TEST-*.xml"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
           npm run report
       - name: Publish test report files
         if: success() || failure() # always run even if the previous step fails
-        uses: actions/upload-artifact@v4.4.3
+        uses: actions/upload-artifact@v4.5.0
         with:
           name: "test-ut-report-files"
           path: |
@@ -169,7 +169,7 @@ jobs:
       - if: success()
         run: echo "true" > test-it-status-${{ matrix.scope }}.txt
 
-      - uses: actions/upload-artifact@v4.4.3
+      - uses: actions/upload-artifact@v4.5.0
         if: success() || failure()
         with:
           name: test-it-status-${{ matrix.scope }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,7 @@ jobs:
       - if: github.event.pull_request.head.repo.fork
         name: Failing job that is executed from forked repo
         run: exit 1
-      - uses: javiertuya/sonarqube-action@v1.4.0
+      - uses: javiertuya/sonarqube-action@v1.4.1
         with: 
           github-token: ${{ secrets.GITHUB_TOKEN }}
           sonar-token: ${{ secrets.SONAR_TOKEN }}

--- a/dashgit-updater/pom.xml
+++ b/dashgit-updater/pom.xml
@@ -72,7 +72,7 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-web</artifactId>
-			<version>6.2.0</version>
+			<version>6.2.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.httpcomponents.client5</groupId>

--- a/dashgit-updater/pom.xml
+++ b/dashgit-updater/pom.xml
@@ -66,7 +66,7 @@
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-slf4j2-impl</artifactId>
-			<version>2.24.2</version>
+			<version>2.24.3</version>
 		</dependency>
 
 		<dependency>

--- a/dashgit-updater/pom.xml
+++ b/dashgit-updater/pom.xml
@@ -93,7 +93,7 @@
 		<dependency>
 			<groupId>org.eclipse.jgit</groupId>
 			<artifactId>org.eclipse.jgit</artifactId>
-			<version>7.0.0.202409031743-r</version>
+			<version>7.1.0.202411261347-r</version>
 		</dependency>
 
 	</dependencies>

--- a/dashgit-updater/pom.xml
+++ b/dashgit-updater/pom.xml
@@ -49,7 +49,7 @@
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-text</artifactId>
-			<version>1.12.0</version>
+			<version>1.13.0</version>
 		</dependency>
 		
 		<dependency>

--- a/dashgit-web/app/package.json
+++ b/dashgit-web/app/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "dependencies": {
     "@octokit/rest": "21.0.2",
-    "@octokit/graphql": "8.1.1",
-    "@gitbeaker/rest": "41.3.0"
+    "@octokit/graphql": "8.1.2",
+    "@gitbeaker/rest": "42.0.1"
   }
 }

--- a/dashgit-web/test/package.json
+++ b/dashgit-web/test/package.json
@@ -8,7 +8,7 @@
     "report": "mocha Test*.js --reporter mochawesome"
   },
   "dependencies": {
-    "mocha": "10.8.2",
+    "mocha": "11.0.1",
     "chai": "5.1.2",
     "mochawesome": "7.1.3"
   }


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump actions/upload-artifact from 4.4.3 to 4.5.0](https://github.com/javiertuya/dashgit/pull/141)
- [Bump javiertuya/sonarqube-action from 1.4.0 to 1.4.1](https://github.com/javiertuya/dashgit/pull/140)
- [Bump mikepenz/action-junit-report from 5.1.0 to 5.2.0](https://github.com/javiertuya/dashgit/pull/139)
- [Bump org.springframework:spring-web from 6.2.0 to 6.2.1 in /dashgit-updater](https://github.com/javiertuya/dashgit/pull/138)
- [Bump org.apache.logging.log4j:log4j-slf4j2-impl from 2.24.2 to 2.24.3 in /dashgit-updater](https://github.com/javiertuya/dashgit/pull/137)
- [Bump org.apache.commons:commons-text from 1.12.0 to 1.13.0 in /dashgit-updater](https://github.com/javiertuya/dashgit/pull/136)
- [Bump org.eclipse.jgit:org.eclipse.jgit from 7.0.0.202409031743-r to 7.1.0.202411261347-r in /dashgit-updater](https://github.com/javiertuya/dashgit/pull/135)
- [Bump mocha from 10.8.2 to 11.0.1 in /dashgit-web/test](https://github.com/javiertuya/dashgit/pull/134)
- [Bump the web-manual-updates group in /dashgit-web/app with 2 updates](https://github.com/javiertuya/dashgit/pull/133)