### PR TITLE
Combined dependency updates (2025-02-03)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -158,7 +158,7 @@ jobs:
 
       - name: Generate report checks - ${{ matrix.scope }}
         if: success() || failure()
-        uses: mikepenz/action-junit-report@v5.2.0
+        uses: mikepenz/action-junit-report@v5.3.0
         with:
           check_name: "test-it-result-${{ matrix.scope }}"
           report_paths: "**/surefire-reports/TEST-*.xml"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
           npm run report
       - name: Publish test report files
         if: success() || failure() # always run even if the previous step fails
-        uses: actions/upload-artifact@v4.5.0
+        uses: actions/upload-artifact@v4.6.0
         with:
           name: "test-ut-report-files"
           path: |
@@ -169,7 +169,7 @@ jobs:
       - if: success()
         run: echo "true" > test-it-status-${{ matrix.scope }}.txt
 
-      - uses: actions/upload-artifact@v4.5.0
+      - uses: actions/upload-artifact@v4.6.0
         if: success() || failure()
         with:
           name: test-it-status-${{ matrix.scope }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -126,7 +126,7 @@ jobs:
       - name: Set up & wait mutex - ${{ matrix.scope }}
         env: 
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        uses: ben-z/gh-action-mutex@v1.0.0-alpha.9
+        uses: ben-z/gh-action-mutex@v1.0.0-alpha.10
         with:
           branch: gh-mutex-${{ matrix.scope }}
 

--- a/dashgit-updater/pom.xml
+++ b/dashgit-updater/pom.xml
@@ -72,7 +72,7 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-web</artifactId>
-			<version>6.2.1</version>
+			<version>6.2.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.httpcomponents.client5</groupId>

--- a/dashgit-web/app/package.json
+++ b/dashgit-web/app/package.json
@@ -1,8 +1,8 @@
 {
   "type": "module",
   "dependencies": {
-    "@octokit/rest": "21.0.2",
-    "@octokit/graphql": "8.1.2",
-    "@gitbeaker/rest": "42.0.1"
+    "@octokit/rest": "21.1.0",
+    "@octokit/graphql": "8.2.0",
+    "@gitbeaker/rest": "42.1.0"
   }
 }

--- a/dashgit-web/test/package.json
+++ b/dashgit-web/test/package.json
@@ -8,7 +8,7 @@
     "report": "mocha Test*.js --reporter mochawesome"
   },
   "dependencies": {
-    "mocha": "11.0.1",
+    "mocha": "11.1.0",
     "chai": "5.1.2",
     "mochawesome": "7.1.3"
   }


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump mikepenz/action-junit-report from 5.2.0 to 5.3.0](https://github.com/javiertuya/dashgit/pull/148)
- [Bump ben-z/gh-action-mutex from 1.0.0.pre.alpha.9 to 1.0.0.pre.alpha.10](https://github.com/javiertuya/dashgit/pull/147)
- [Bump actions/upload-artifact from 4.5.0 to 4.6.0](https://github.com/javiertuya/dashgit/pull/146)
- [Bump org.springframework:spring-web from 6.2.1 to 6.2.2 in /dashgit-updater](https://github.com/javiertuya/dashgit/pull/145)
- [Bump mocha from 11.0.1 to 11.1.0 in /dashgit-web/test](https://github.com/javiertuya/dashgit/pull/144)
- [Bump the web-manual-updates group in /dashgit-web/app with 3 updates](https://github.com/javiertuya/dashgit/pull/143)