### PR TITLE
Combined dependency updates (2025-05-23)

### DIFF
--- a/dashgit-updater/pom.xml
+++ b/dashgit-updater/pom.xml
@@ -93,7 +93,7 @@
 		<dependency>
 			<groupId>org.eclipse.jgit</groupId>
 			<artifactId>org.eclipse.jgit</artifactId>
-			<version>7.2.0.202503040940-r</version>
+			<version>7.2.1.202505142326-r</version>
 		</dependency>
 
 	</dependencies>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump org.eclipse.jgit:org.eclipse.jgit from 7.2.0.202503040940-r to 7.2.1.202505142326-r in /dashgit-updater](https://github.com/javiertuya/dashgit/pull/180)
- [Bump org.springframework:spring-web from 6.2.6 to 6.2.7 in /dashgit-updater](https://github.com/javiertuya/dashgit/pull/181)
- [Bump org.apache.httpcomponents.client5:httpclient5 from 5.4.4 to 5.5 in /dashgit-updater](https://github.com/javiertuya/dashgit/pull/182)