### PR TITLE
Combined dependency updates (2025-06-07)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -165,7 +165,7 @@ jobs:
 
       - name: Generate report checks - ${{ matrix.scope }}
         if: success() || failure()
-        uses: mikepenz/action-junit-report@v5.5.1
+        uses: mikepenz/action-junit-report@v5.6.0
         with:
           check_name: "test-it-result-${{ matrix.scope }}"
           report_paths: "**/surefire-reports/TEST-*.xml"

--- a/dashgit-web/app/package.json
+++ b/dashgit-web/app/package.json
@@ -1,8 +1,8 @@
 {
   "type": "module",
   "dependencies": {
-    "@octokit/rest": "21.1.1",
-    "@octokit/graphql": "8.2.2",
+    "@octokit/rest": "22.0.0",
+    "@octokit/graphql": "9.0.1",
     "@gitbeaker/rest": "42.5.0"
   }
 }

--- a/dashgit-web/test/package.json
+++ b/dashgit-web/test/package.json
@@ -8,7 +8,7 @@
     "report": "mocha Test*.js --reporter mochawesome"
   },
   "dependencies": {
-    "mocha": "11.2.2",
+    "mocha": "11.5.0",
     "chai": "5.2.0",
     "mochawesome": "7.1.3"
   }


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump mocha from 11.2.2 to 11.5.0 in /dashgit-web/test](https://github.com/javiertuya/dashgit/pull/187)
- [Bump mikepenz/action-junit-report from 5.5.1 to 5.6.0](https://github.com/javiertuya/dashgit/pull/186)
- [Bump the web-manual-updates group in /dashgit-web/app with 2 updates](https://github.com/javiertuya/dashgit/pull/185)