### PR TITLE
Combined dependency updates (2025-07-04)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -165,7 +165,7 @@ jobs:
 
       - name: Generate report checks - ${{ matrix.scope }}
         if: success() || failure()
-        uses: mikepenz/action-junit-report@v5.6.0
+        uses: mikepenz/action-junit-report@v5.6.1
         with:
           check_name: "test-it-result-${{ matrix.scope }}"
           report_paths: "**/surefire-reports/TEST-*.xml"

--- a/dashgit-updater/pom.xml
+++ b/dashgit-updater/pom.xml
@@ -93,7 +93,7 @@
 		<dependency>
 			<groupId>org.eclipse.jgit</groupId>
 			<artifactId>org.eclipse.jgit</artifactId>
-			<version>7.2.1.202505142326-r</version>
+			<version>7.3.0.202506031305-r</version>
 		</dependency>
 
 	</dependencies>

--- a/dashgit-updater/pom.xml
+++ b/dashgit-updater/pom.xml
@@ -72,7 +72,7 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-web</artifactId>
-			<version>6.2.7</version>
+			<version>6.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.httpcomponents.client5</groupId>

--- a/dashgit-updater/pom.xml
+++ b/dashgit-updater/pom.xml
@@ -66,7 +66,7 @@
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-slf4j2-impl</artifactId>
-			<version>2.24.3</version>
+			<version>2.25.0</version>
 		</dependency>
 
 		<dependency>

--- a/dashgit-web/test/package.json
+++ b/dashgit-web/test/package.json
@@ -8,7 +8,7 @@
     "report": "mocha Test*.js --reporter mochawesome"
   },
   "dependencies": {
-    "mocha": "11.5.0",
+    "mocha": "11.7.1",
     "chai": "5.2.0",
     "mochawesome": "7.1.3"
   }


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump org.apache.logging.log4j:log4j-slf4j2-impl from 2.24.3 to 2.25.0 in /dashgit-updater](https://github.com/javiertuya/dashgit/pull/194)
- [Bump org.eclipse.jgit:org.eclipse.jgit from 7.2.1.202505142326-r to 7.3.0.202506031305-r in /dashgit-updater](https://github.com/javiertuya/dashgit/pull/193)
- [Bump mocha from 11.5.0 to 11.7.1 in /dashgit-web/test](https://github.com/javiertuya/dashgit/pull/191)
- [Bump mikepenz/action-junit-report from 5.6.0 to 5.6.1](https://github.com/javiertuya/dashgit/pull/190)
- [Bump org.springframework:spring-web from 6.2.7 to 6.2.8 in /dashgit-updater](https://github.com/javiertuya/dashgit/pull/189)