### PR TITLE
Combined dependency updates (2025-08-02)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,7 @@ jobs:
       - if: github.event.pull_request.head.repo.fork
         name: Failing job that is executed from forked repo
         run: exit 1
-      - uses: javiertuya/sonarqube-action@v1.4.2
+      - uses: javiertuya/sonarqube-action@v1.4.3
         with: 
           github-token: ${{ secrets.GITHUB_TOKEN }}
           sonar-token: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -165,7 +165,7 @@ jobs:
 
       - name: Generate report checks - ${{ matrix.scope }}
         if: success() || failure()
-        uses: mikepenz/action-junit-report@v5.6.1
+        uses: mikepenz/action-junit-report@v5.6.2
         with:
           check_name: "test-it-result-${{ matrix.scope }}"
           report_paths: "**/surefire-reports/TEST-*.xml"

--- a/dashgit-updater/pom.xml
+++ b/dashgit-updater/pom.xml
@@ -72,7 +72,7 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-web</artifactId>
-			<version>6.2.8</version>
+			<version>6.2.9</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.httpcomponents.client5</groupId>

--- a/dashgit-updater/pom.xml
+++ b/dashgit-updater/pom.xml
@@ -83,7 +83,7 @@
 		<dependency>
 			<groupId>org.kohsuke</groupId>
 			<artifactId>github-api</artifactId>
-			<version>1.327</version>
+			<version>1.329</version>
 		</dependency>
 		<dependency>
 			<groupId>org.gitlab4j</groupId>

--- a/dashgit-updater/pom.xml
+++ b/dashgit-updater/pom.xml
@@ -66,7 +66,7 @@
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-slf4j2-impl</artifactId>
-			<version>2.25.0</version>
+			<version>2.25.1</version>
 		</dependency>
 
 		<dependency>

--- a/dashgit-updater/pom.xml
+++ b/dashgit-updater/pom.xml
@@ -88,7 +88,7 @@
 		<dependency>
 			<groupId>org.gitlab4j</groupId>
 			<artifactId>gitlab4j-api</artifactId>
-			<version>6.0.0</version>
+			<version>6.1.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.jgit</groupId>

--- a/dashgit-updater/pom.xml
+++ b/dashgit-updater/pom.xml
@@ -49,7 +49,7 @@
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-text</artifactId>
-			<version>1.13.1</version>
+			<version>1.14.0</version>
 		</dependency>
 		
 		<dependency>

--- a/dashgit-web/app/package.json
+++ b/dashgit-web/app/package.json
@@ -3,6 +3,6 @@
   "dependencies": {
     "@octokit/rest": "22.0.0",
     "@octokit/graphql": "9.0.1",
-    "@gitbeaker/rest": "42.5.0"
+    "@gitbeaker/rest": "43.3.0"
   }
 }

--- a/dashgit-web/test/package.json
+++ b/dashgit-web/test/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "mocha": "11.7.1",
-    "chai": "5.2.0",
+    "chai": "5.2.1",
     "mochawesome": "7.1.3"
   }
 }


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump mikepenz/action-junit-report from 5.6.1 to 5.6.2](https://github.com/javiertuya/dashgit/pull/204)
- [Bump javiertuya/sonarqube-action from 1.4.2 to 1.4.3](https://github.com/javiertuya/dashgit/pull/203)
- [Bump org.apache.logging.log4j:log4j-slf4j2-impl from 2.25.0 to 2.25.1 in /dashgit-updater](https://github.com/javiertuya/dashgit/pull/202)
- [Bump org.gitlab4j:gitlab4j-api from 6.0.0 to 6.1.0 in /dashgit-updater](https://github.com/javiertuya/dashgit/pull/201)
- [Bump org.apache.commons:commons-text from 1.13.1 to 1.14.0 in /dashgit-updater](https://github.com/javiertuya/dashgit/pull/200)
- [Bump org.springframework:spring-web from 6.2.8 to 6.2.9 in /dashgit-updater](https://github.com/javiertuya/dashgit/pull/199)
- [Bump org.kohsuke:github-api from 1.327 to 1.329 in /dashgit-updater](https://github.com/javiertuya/dashgit/pull/198)
- [Bump @gitbeaker/rest from 42.5.0 to 43.3.0 in /dashgit-web/app in the web-manual-updates group](https://github.com/javiertuya/dashgit/pull/197)
- [Bump chai from 5.2.0 to 5.2.1 in /dashgit-web/test](https://github.com/javiertuya/dashgit/pull/196)