### PR TITLE
Combined dependency updates (2025-10-04)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Checkout GitHub repo
         uses: actions/checkout@v5
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '18.x' 
       - name: Run unit tests

--- a/dashgit-updater/pom.xml
+++ b/dashgit-updater/pom.xml
@@ -77,7 +77,7 @@
 		<dependency>
 			<groupId>org.apache.httpcomponents.client5</groupId>
 			<artifactId>httpclient5</artifactId>
-			<version>5.5</version>
+			<version>5.5.1</version>
 		</dependency>
 
 		<dependency>

--- a/dashgit-updater/pom.xml
+++ b/dashgit-updater/pom.xml
@@ -55,7 +55,7 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<version>1.18.38</version>
+			<version>1.18.42</version>
 		</dependency>
 
 		<dependency>

--- a/dashgit-updater/pom.xml
+++ b/dashgit-updater/pom.xml
@@ -83,7 +83,7 @@
 		<dependency>
 			<groupId>org.kohsuke</groupId>
 			<artifactId>github-api</artifactId>
-			<version>1.329</version>
+			<version>1.330</version>
 		</dependency>
 		<dependency>
 			<groupId>org.gitlab4j</groupId>

--- a/dashgit-updater/pom.xml
+++ b/dashgit-updater/pom.xml
@@ -66,7 +66,7 @@
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-slf4j2-impl</artifactId>
-			<version>2.25.1</version>
+			<version>2.25.2</version>
 		</dependency>
 
 		<dependency>

--- a/dashgit-updater/pom.xml
+++ b/dashgit-updater/pom.xml
@@ -72,7 +72,7 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-web</artifactId>
-			<version>6.2.10</version>
+			<version>6.2.11</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.httpcomponents.client5</groupId>

--- a/dashgit-web/app/package.json
+++ b/dashgit-web/app/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "dependencies": {
     "@octokit/rest": "22.0.0",
-    "@octokit/graphql": "9.0.1",
-    "@gitbeaker/rest": "43.4.0"
+    "@octokit/graphql": "9.0.2",
+    "@gitbeaker/rest": "43.5.0"
   }
 }

--- a/dashgit-web/test/package.json
+++ b/dashgit-web/test/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "mocha": "11.7.2",
-    "chai": "6.0.1",
+    "chai": "6.2.0",
     "mochawesome": "7.1.4"
   }
 }

--- a/dashgit-web/test/package.json
+++ b/dashgit-web/test/package.json
@@ -10,6 +10,6 @@
   "dependencies": {
     "mocha": "11.7.2",
     "chai": "6.0.1",
-    "mochawesome": "7.1.3"
+    "mochawesome": "7.1.4"
   }
 }

--- a/dashgit-web/test/package.json
+++ b/dashgit-web/test/package.json
@@ -8,7 +8,7 @@
     "report": "mocha Test*.js --reporter mochawesome"
   },
   "dependencies": {
-    "mocha": "11.7.2",
+    "mocha": "11.7.3",
     "chai": "6.2.0",
     "mochawesome": "7.1.4"
   }


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump org.projectlombok:lombok from 1.18.38 to 1.18.42 in /dashgit-updater](https://github.com/javiertuya/dashgit/pull/230)
- [Bump mochawesome from 7.1.3 to 7.1.4 in /dashgit-web/test](https://github.com/javiertuya/dashgit/pull/233)
- [Bump chai from 6.0.1 to 6.2.0 in /dashgit-web/test](https://github.com/javiertuya/dashgit/pull/232)
- [Bump mocha from 11.7.2 to 11.7.3 in /dashgit-web/test](https://github.com/javiertuya/dashgit/pull/231)
- [Bump org.springframework:spring-web from 6.2.10 to 6.2.11 in /dashgit-updater](https://github.com/javiertuya/dashgit/pull/229)
- [Bump org.apache.logging.log4j:log4j-slf4j2-impl from 2.25.1 to 2.25.2 in /dashgit-updater](https://github.com/javiertuya/dashgit/pull/228)
- [Bump org.apache.httpcomponents.client5:httpclient5 from 5.5 to 5.5.1 in /dashgit-updater](https://github.com/javiertuya/dashgit/pull/227)
- [Bump org.kohsuke:github-api from 1.329 to 1.330 in /dashgit-updater](https://github.com/javiertuya/dashgit/pull/226)
- [Bump actions/setup-node from 4 to 5](https://github.com/javiertuya/dashgit/pull/225)
- [Bump the web-manual-updates group in /dashgit-web/app with 2 updates](https://github.com/javiertuya/dashgit/pull/224)