### PR TITLE
Combined dependency updates (2026-05-02)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
           ./prepare-release.sh "$GITHUB_REF_NAME"
 
       - name: Upload artifact to deploy
-        uses: actions/upload-pages-artifact@v4.0.0
+        uses: actions/upload-pages-artifact@v5.0.0
         with:
           path: 'dashgit-web/dist'
       - name: Deploy to GitHub Pages

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
           npm run report
       - name: Publish test report files
         if: success() || failure() # always run even if the previous step fails
-        uses: actions/upload-artifact@v7.0.0
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: "test-ut-report-files"
           path: |
@@ -178,7 +178,7 @@ jobs:
       - if: success()
         run: echo "true" > test-it-status-${{ matrix.scope }}.txt
 
-      - uses: actions/upload-artifact@v7.0.0
+      - uses: actions/upload-artifact@v7.0.1
         if: success() || failure()
         with:
           name: test-it-status-${{ matrix.scope }}

--- a/dashgit-updater/pom.xml
+++ b/dashgit-updater/pom.xml
@@ -77,7 +77,7 @@
 		<dependency>
 			<groupId>org.apache.httpcomponents.client5</groupId>
 			<artifactId>httpclient5</artifactId>
-			<version>5.6</version>
+			<version>5.6.1</version>
 		</dependency>
 
 		<dependency>

--- a/dashgit-updater/pom.xml
+++ b/dashgit-updater/pom.xml
@@ -55,7 +55,7 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<version>1.18.44</version>
+			<version>1.18.46</version>
 		</dependency>
 
 		<dependency>

--- a/dashgit-updater/pom.xml
+++ b/dashgit-updater/pom.xml
@@ -72,7 +72,7 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-web</artifactId>
-			<version>7.0.6</version>
+			<version>7.0.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.httpcomponents.client5</groupId>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump org.springframework:spring-web from 7.0.6 to 7.0.7 in /dashgit-updater](https://github.com/javiertuya/dashgit/pull/286)
- [Bump org.projectlombok:lombok from 1.18.44 to 1.18.46 in /dashgit-updater](https://github.com/javiertuya/dashgit/pull/292)
- [Bump org.apache.httpcomponents.client5:httpclient5 from 5.6 to 5.6.1 in /dashgit-updater](https://github.com/javiertuya/dashgit/pull/288)
- [Bump actions/upload-artifact from 7.0.0 to 7.0.1](https://github.com/javiertuya/dashgit/pull/287)
- [Bump actions/upload-pages-artifact from 4.0.0 to 5.0.0](https://github.com/javiertuya/dashgit/pull/289)