### PR TITLE
Combined dependency updates (2026-06-02)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -167,7 +167,7 @@ jobs:
 
       - name: Generate report checks - ${{ matrix.scope }}
         if: success() || failure()
-        uses: mikepenz/action-junit-report@v6.4.0
+        uses: mikepenz/action-junit-report@v6.4.1
         with:
           check_name: "test-it-result-${{ matrix.scope }}"
           report_paths: "**/surefire-reports/TEST-*.xml"

--- a/dashgit-updater/pom.xml
+++ b/dashgit-updater/pom.xml
@@ -61,7 +61,7 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>2.0.17</version>
+			<version>2.0.18</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>

--- a/dashgit-updater/pom.xml
+++ b/dashgit-updater/pom.xml
@@ -66,7 +66,7 @@
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-slf4j2-impl</artifactId>
-			<version>2.25.4</version>
+			<version>2.26.0</version>
 		</dependency>
 
 		<dependency>

--- a/dashgit-updater/pom.xml
+++ b/dashgit-updater/pom.xml
@@ -88,7 +88,7 @@
 		<dependency>
 			<groupId>org.gitlab4j</groupId>
 			<artifactId>gitlab4j-api</artifactId>
-			<version>6.2.0</version>
+			<version>6.3.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.jgit</groupId>

--- a/dashgit-web/test/package.json
+++ b/dashgit-web/test/package.json
@@ -8,7 +8,7 @@
     "report": "mocha Test*.js --reporter mochawesome"
   },
   "dependencies": {
-    "mocha": "11.7.5",
+    "mocha": "11.7.6",
     "sinon": "21.1.2",
     "chai": "6.2.2",
     "mochawesome": "7.1.4"

--- a/dashgit-web/test/package.json
+++ b/dashgit-web/test/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "mocha": "11.7.5",
-    "sinon": "21.1.2",
+    "sinon": "22.0.0",
     "chai": "6.2.2",
     "mochawesome": "7.1.4"
   }


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump mocha from 11.7.5 to 11.7.6 in /dashgit-web/test](https://github.com/javiertuya/dashgit/pull/303)
- [Bump sinon from 21.1.2 to 22.0.0 in /dashgit-web/test](https://github.com/javiertuya/dashgit/pull/302)
- [Bump org.slf4j:slf4j-api from 2.0.17 to 2.0.18 in /dashgit-updater](https://github.com/javiertuya/dashgit/pull/301)
- [Bump org.apache.logging.log4j:log4j-slf4j2-impl from 2.25.4 to 2.26.0 in /dashgit-updater](https://github.com/javiertuya/dashgit/pull/300)
- [Bump org.gitlab4j:gitlab4j-api from 6.2.0 to 6.3.0 in /dashgit-updater](https://github.com/javiertuya/dashgit/pull/299)
- [Bump mikepenz/action-junit-report from 6.4.0 to 6.4.1](https://github.com/javiertuya/dashgit/pull/298)