### PR TITLE
Combined dependency updates (2026-07-04)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Setup Pages
         uses: actions/configure-pages@v6
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
           echo "fork: ${{ github.event.pull_request.head.repo.fork }}"
           echo "head ref: ${{ github.head_ref }}"
       - name: Checkout GitHub repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Use Node.js
         uses: actions/setup-node@v6
         with:
@@ -93,7 +93,7 @@ jobs:
     #if: ${{ false }}
     if: (github.event_name != 'pull_request' && ! github.event.pull_request.head.repo.fork) || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.fork || startsWith(github.head_ref, 'dependabot/')))
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - run: echo "current branch ${{ github.ref_name }}"
     - uses: dorny/paths-filter@v4.0.1
       id: filter
@@ -118,7 +118,7 @@ jobs:
     needs:  test-it-trigger
     if: needs.test-it-trigger.outputs.output1 == 'true'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       # workaround #35, avoid infinite loop of ben-z/gh-action-mutex, issue #15
       - if: github.event.pull_request.head.repo.fork

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -167,7 +167,7 @@ jobs:
 
       - name: Generate report checks - ${{ matrix.scope }}
         if: success() || failure()
-        uses: mikepenz/action-junit-report@v6.4.1
+        uses: mikepenz/action-junit-report@v6.4.2
         with:
           check_name: "test-it-result-${{ matrix.scope }}"
           report_paths: "**/surefire-reports/TEST-*.xml"

--- a/dashgit-updater/pom.xml
+++ b/dashgit-updater/pom.xml
@@ -77,7 +77,7 @@
 		<dependency>
 			<groupId>org.apache.httpcomponents.client5</groupId>
 			<artifactId>httpclient5</artifactId>
-			<version>5.6.1</version>
+			<version>5.6.2</version>
 		</dependency>
 
 		<dependency>

--- a/dashgit-updater/pom.xml
+++ b/dashgit-updater/pom.xml
@@ -93,7 +93,7 @@
 		<dependency>
 			<groupId>org.eclipse.jgit</groupId>
 			<artifactId>org.eclipse.jgit</artifactId>
-			<version>7.6.0.202603022253-r</version>
+			<version>7.7.0.202606012155-r</version>
 		</dependency>
 
 	</dependencies>

--- a/dashgit-updater/pom.xml
+++ b/dashgit-updater/pom.xml
@@ -72,7 +72,7 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-web</artifactId>
-			<version>7.0.7</version>
+			<version>7.0.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.httpcomponents.client5</groupId>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump org.eclipse.jgit:org.eclipse.jgit from 7.6.0.202603022253-r to 7.7.0.202606012155-r in /dashgit-updater](https://github.com/javiertuya/dashgit/pull/310)
- [Bump org.springframework:spring-web from 7.0.7 to 7.0.8 in /dashgit-updater](https://github.com/javiertuya/dashgit/pull/309)
- [Bump org.apache.httpcomponents.client5:httpclient5 from 5.6.1 to 5.6.2 in /dashgit-updater](https://github.com/javiertuya/dashgit/pull/307)
- [Bump mikepenz/action-junit-report from 6.4.1 to 6.4.2](https://github.com/javiertuya/dashgit/pull/308)
- [Bump actions/checkout from 6 to 7](https://github.com/javiertuya/dashgit/pull/306)