### PR TITLE
Combined dependency updates (2026-07-11)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -125,7 +125,7 @@ jobs:
     steps:
     - uses: actions/checkout@v7
     - run: echo "current branch ${{ github.ref_name }}"
-    - uses: dorny/paths-filter@v4.0.1
+    - uses: dorny/paths-filter@v4.0.2
       id: filter
       with:
         base: ${{ github.ref_name }}

--- a/dashgit-updater/pom.xml
+++ b/dashgit-updater/pom.xml
@@ -42,7 +42,7 @@
 		<dependency>
 			<groupId>io.github.javiertuya</groupId>
 			<artifactId>visual-assert</artifactId>
-			<version>2.6.1</version>
+			<version>2.6.2</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/dashgit-updater/pom.xml
+++ b/dashgit-updater/pom.xml
@@ -66,7 +66,7 @@
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-slf4j2-impl</artifactId>
-			<version>2.26.0</version>
+			<version>2.26.1</version>
 		</dependency>
 
 		<dependency>

--- a/dashgit-updater/pom.xml
+++ b/dashgit-updater/pom.xml
@@ -37,7 +37,7 @@
 		<dependency>
 			<groupId>io.github.javiertuya</groupId>
 			<artifactId>portable-java</artifactId>
-			<version>2.4.3</version>
+			<version>2.4.4</version>
 		</dependency>
 		<dependency>
 			<groupId>io.github.javiertuya</groupId>

--- a/dashgit-web/e2e/package.json
+++ b/dashgit-web/e2e/package.json
@@ -9,7 +9,7 @@
     "report": "playwright show-report"
   },
   "devDependencies": {
-    "@playwright/test": "1.56.1",
+    "@playwright/test": "1.61.1",
     "http-server": "14.1.1"
   }
 }


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump @playwright/test from 1.56.1 to 1.61.1 in /dashgit-web/e2e](https://github.com/javiertuya/dashgit/pull/317)
- [Bump io.github.javiertuya:portable-java from 2.4.3 to 2.4.4 in /dashgit-updater](https://github.com/javiertuya/dashgit/pull/316)
- [Bump org.apache.logging.log4j:log4j-slf4j2-impl from 2.26.0 to 2.26.1 in /dashgit-updater](https://github.com/javiertuya/dashgit/pull/315)
- [Bump io.github.javiertuya:visual-assert from 2.6.1 to 2.6.2 in /dashgit-updater](https://github.com/javiertuya/dashgit/pull/314)
- [Bump dorny/paths-filter from 4.0.1 to 4.0.2](https://github.com/javiertuya/dashgit/pull/313)