### PR TITLE
feat: add run.py to serve DashGit locally without Docker/Node

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,21 @@ jobs:
             dashgit-web/test/actual
             dashgit-web/test/mochawesome-report
 
+  test-ut-server-py:
+    runs-on: ubuntu-latest
+    # As in test-ut: avoids duplicate execution of pr from local repo, but allows pr from forked repos and dependabot
+    if: (github.event_name != 'pull_request' && ! github.event.pull_request.head.repo.fork) || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.fork || startsWith(github.head_ref, 'dependabot/')))
+    steps:
+      - name: Checkout GitHub repo
+        uses: actions/checkout@v7
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+      - name: Run unit tests for server.py
+        working-directory: ./dashgit-server-py
+        run: python3 -m unittest test_server.py -v
+
   test-e2e:
     runs-on: ubuntu-latest
     # As in test-ut: avoids duplicate execution of pr from local repo, but allows pr from forked repos and dependabot

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 temp
+.env
+__pycache__

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ This is a multi-component workspace. There is **no `package.json` at the reposit
 | Component | Path | Stack | Purpose |
 | --------- | ---- | ----- | ------- |
 | Web app | `dashgit-web/` | Vanilla JS (ES modules), static HTML/CSS | The DashGit UI — the main component |
+| Local runner | `dashgit-server-py/` | Python 3.7+ stdlib | Runs the web app + OAuth proxy together on one port |
 | Updater | `dashgit-updater/` | Java 17 / Maven | Generates and applies combined Dependabot update payloads |
 | OAuth proxy | `oauth-exchange/` | Node.js / Express 5 | Exchanges OAuth authorization codes for tokens without exposing secrets |
 
@@ -76,8 +77,19 @@ From `dashgit-updater/`:
 ### OAuth proxy
 From `oauth-exchange/`: `npm install` then run `server.js` with the required OAuth environment variables set.
 
+### Run everything locally
+`dashgit-server-py/server.py` serves `dashgit-web/app/` as static files plus the OAuth proxy's `/exchange` and `/healthcheck` on the same port, i.e. the whole stack:
+```
+python3 dashgit-server-py/server.py [port] # http://127.0.0.1:8080, or the given port
+```
+- Binds `127.0.0.1` only, no CORS headers: app and `/exchange` are same-origin.
+- Credentials `CLIENT_SECRET_<client_id>` / `TOKEN_URL_<client_id>` come from `dashgit-server-py/.env` (format in `.env.example`); shell environment wins over `.env`, so a wrapper can inject them from a secret manager.
+- OAuth setup (own *App*, callback URL, address must match the browser's address bar exactly) is in `dashgit-web/OAUTH2.md`, section "Run everything locally". Do not restate it here.
+- Tests for the exchange decision logic (`prepare_exchange`): `cd dashgit-server-py && python3 -m unittest test_server.py`. Named `TestUt*` to mirror the updater's JUnit tests.
+- `oauth-exchange/server.js` + `Dockerfile` remain the Node/Docker alternative for containerized deployment; `dashgit-server-py/` is local-only.
+
 ## CI/CD (`.github/workflows/`)
-- `test.yml` — on push/PR: `test-ut` (web Mocha tests, Node 24), `test-e2e` (Playwright e2e, Node 24), `sonarqube` analysis, and a `test-it` matrix (GitHub/GitLab integration tests, only when files under `dashgit-updater/**` change).
+- `test.yml` — on push/PR: `test-ut` (web Mocha tests, Node 24), `test-ut-server-py` (`dashgit-server-py` unittest), `test-e2e` (Playwright e2e, Node 24), `sonarqube` analysis, and a `test-it` matrix (GitHub/GitLab integration tests, only when files under `dashgit-updater/**` change).
 - `release.yml` — on GitHub Release: runs `prepare-release.sh` and deploys `dashgit-web/dist/` to GitHub Pages.
 - Sonar configuration is in `sonar-project.properties` (analyzes `dashgit-web/app` and `dashgit-updater/src/main/java`).
 - **Analysis runs on SonarCloud (public project key `my:dashgit`)**, so its API is reachable without auth — no token needed to read results. When the `sonarqube` job fails, `gh run view <id> --log-failed` only shows "Quality Gate has FAILED"; get the actual cause from the public API (URL-encode the `:` as `%3A`):

--- a/README.md
+++ b/README.md
@@ -51,6 +51,15 @@ The configuration is stored in your browser's local storage.
 OAuth tokens are stored in session storage, dropped after closing the browser tab.
 If you authenticate using Personal Access Tokens (PAT) you can encrypt them with a password, which will be requested when you open a new DashGit browser tab.
 
+### Running your own instance locally
+
+`dashgit-server-py/server.py` runs both the web server and the exchange proxy server locally on a single port, requiring only Python (no Docker or Node):
+```
+python3 dashgit-server-py/server.py
+```
+DashGit is then available at `http://127.0.0.1:8080`.
+See [OAUTH2.md](dashgit-web/OAUTH2.md) for how to configure it to use your own OAuth App.
+
 ## Features and Configuration
 
 The different *views* (tabs) in the UI display open *work items* (issues, pull requests, etc.) in a collapsible panel for each *provider*.

--- a/dashgit-server-py/.env.example
+++ b/dashgit-server-py/.env.example
@@ -1,0 +1,11 @@
+# GitHub OAuth credentials (create OAuth app at https://github.com/settings/developers)
+# Callback URL: http://127.0.0.1:8080/
+
+# Replace 'your_github_client_id' with your actual GitHub OAuth App Client ID
+CLIENT_SECRET_your_github_client_id=your_github_client_secret
+TOKEN_URL_your_github_client_id=https://github.com/login/oauth/access_token
+
+# Optional: GitLab OAuth credentials (create app at Settings > Applications)
+# Replace 'your_gitlab_app_id' with your actual GitLab Application ID
+# CLIENT_SECRET_your_gitlab_app_id=your_gitlab_app_secret
+# TOKEN_URL_your_gitlab_app_id=https://gitlab.com/oauth/token

--- a/dashgit-server-py/server.py
+++ b/dashgit-server-py/server.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""Run DashGit locally: static file server for dashgit-web/app plus the
+OAuth exchange proxy, listening on http://127.0.0.1:8080 by default
+
+Requires Python 3.7 or later, standard library only, no third party packages.
+
+Usage:
+    python3 server.py [port]     # default port 8080
+
+Reads CLIENT_SECRET_<id> / TOKEN_URL_<id> pairs from shell env or .env in this
+folder (same format oauth-exchange/server.js expects), see .env.example.
+"""
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from http.server import ThreadingHTTPServer, SimpleHTTPRequestHandler
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+WEB_APP_DIR = ROOT.parent / "dashgit-web" / "app"
+ENV_FILE = ROOT / ".env"
+VERBOSE = False
+
+
+def load_env_file(path):
+    if not path.exists():
+        return
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        os.environ.setdefault(key.strip(), value.strip())
+
+
+class ExchangeOutcome:
+    """Result of preparing an /exchange request: either an error to return
+    to the client (error=True, status/body set) or a forward request to make
+    to the authorization server (error=False, token_url/body set)."""
+
+    def __init__(self, error, status=None, body=None, token_url=None, log_message=""):
+        self.error = error
+        self.status = status
+        self.body = body
+        self.token_url = token_url
+        self.log_message = log_message
+
+
+def prepare_exchange(payload, environ):
+    """Decision logic for the /exchange endpoint: given the request payload and
+    an environ mapping, decide whether to forbid the request or build the body
+    to forward to the authorization server."""
+    grant_type = payload.get("grant_type")
+    client_id = payload.get("client_id")
+
+    client_secret = environ.get(f"CLIENT_SECRET_{client_id}")
+    token_url = environ.get(f"TOKEN_URL_{client_id}")
+
+    if not client_secret or not token_url:
+        return ExchangeOutcome(
+            error=True, status=403,
+            body={"error": "forbidden", "error_description": "Exchange not allowed"},
+            log_message="Can't find a client secret or token url for this client, returning 403 forbidden",
+        )
+
+    if grant_type == "authorization_code":
+        body = {
+            "client_secret": client_secret,
+            "client_id": client_id,
+            "grant_type": grant_type,
+            "redirect_uri": payload.get("redirect_uri"),
+            "code": payload.get("code"),
+            "code_verifier": payload.get("code_verifier"),
+        }
+    elif grant_type == "refresh_token":
+        body = {
+            "client_secret": client_secret,
+            "refresh_token": payload.get("refresh_token"),
+            "client_id": client_id,
+            "grant_type": grant_type,
+            "redirect_uri": payload.get("redirect_uri"),
+        }
+    else:
+        return ExchangeOutcome(
+            error=True, status=403,
+            body={"error": "forbidden", "error_description": "Grant type not supported"},
+            log_message=f"Grant type {grant_type} is not supported, returning 403 forbidden",
+        )
+
+    return ExchangeOutcome(error=False, token_url=token_url, body=body)
+
+
+class Handler(SimpleHTTPRequestHandler):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, directory=str(WEB_APP_DIR), **kwargs)
+
+    def log_message(self, fmt, *args):
+        if VERBOSE:
+            sys.stderr.write(f"[{self.log_date_time_string()}] {fmt % args}\n")
+
+    def do_GET(self):
+        if self.path == "/healthcheck":
+            self._send_json(200, "OK", as_json=False)
+            return
+        super().do_GET()
+
+    def do_POST(self):
+        if self.path == "/exchange":
+            self._handle_exchange()
+            return
+        self.send_error(404)
+
+    def _handle_exchange(self):
+        length = int(self.headers.get("Content-Length", 0))
+        try:
+            payload = json.loads(self.rfile.read(length) or b"{}")
+        except json.JSONDecodeError:
+            self._send_json(400, {"error": "bad_request", "error_description": "Invalid JSON body"})
+            return
+
+        print(f"Received exchange request: grant_type={payload.get('grant_type')}, "
+              f"client_id={payload.get('client_id')}, redirect_uri={payload.get('redirect_uri')}")
+
+        outcome = prepare_exchange(payload, os.environ)
+        if outcome.error:
+            print(outcome.log_message)
+            self._send_json(outcome.status, outcome.body)
+            return
+        print(f"  Forwarding to {outcome.token_url}")
+
+        req = urllib.request.Request(
+            outcome.token_url,
+            data=json.dumps(outcome.body).encode(),
+            headers={"Content-Type": "application/json", "Accept": "application/json"},
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                data = resp.read()
+        except urllib.error.HTTPError as e:
+            print(f"Response is not OK: {e}")
+            data = e.read()
+        except urllib.error.URLError as e:
+            self._send_json(500, {"error": "server_error", "error_description": str(e)})
+            return
+
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(data)
+
+    # No CORS headers added as the app and /exchange are served from this same origin. 
+    def _send_json(self, status, body, as_json=True):
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json" if as_json else "text/plain")
+        self.end_headers()
+        self.wfile.write((json.dumps(body) if as_json else body).encode())
+
+
+def parse_args(argv):
+    parser = argparse.ArgumentParser(
+        description="Run DashGit locally: static file server for dashgit-web/app "
+                     "plus the OAuth exchange proxy, both on one port.",
+    )
+    parser.add_argument(
+        "port", nargs="?", type=int, default=8080,
+        help="port to listen on (default: 8080, matching dashgit-web/e2e's http-server convention)",
+    )
+    parser.add_argument(
+        "-v", "--verbose", action="store_true",
+        help="log every HTTP request (method, path, status)",
+    )
+    return parser.parse_args(argv)
+
+
+def main():
+    global VERBOSE
+    args = parse_args(sys.argv[1:])
+    VERBOSE = args.verbose
+    load_env_file(ENV_FILE)
+    port = args.port
+    server = ThreadingHTTPServer(("127.0.0.1", port), Handler)
+    print(f"DashGit running at http://127.0.0.1:{port}  (serving {WEB_APP_DIR}, exchange proxy at /exchange)")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/dashgit-server-py/test_server.py
+++ b/dashgit-server-py/test_server.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Self-contained unit tests for server.py's exchange decision logic.
+
+Mirrors dashgit-updater's TestUt* style: pure logic, no live server,
+no network access. Run with: python3 -m unittest test_server.py
+"""
+import unittest
+
+from server import prepare_exchange, load_env_file
+
+ENV = {
+    "CLIENT_SECRET_myclientid": "mysecret",
+    "TOKEN_URL_myclientid": "https://example.test/oauth/token",
+}
+
+
+class TestUtPrepareExchangeForbidden(unittest.TestCase):
+    def test_unknown_client_id_is_forbidden(self):
+        outcome = prepare_exchange(
+            {"grant_type": "authorization_code", "client_id": "nope"}, ENV
+        )
+        self.assertTrue(outcome.error)
+        self.assertEqual(outcome.status, 403)
+        self.assertEqual(outcome.body["error"], "forbidden")
+        self.assertEqual(outcome.body["error_description"], "Exchange not allowed")
+
+    def test_missing_client_id_is_forbidden(self):
+        outcome = prepare_exchange({"grant_type": "authorization_code"}, ENV)
+        self.assertTrue(outcome.error)
+        self.assertEqual(outcome.status, 403)
+
+    def test_unsupported_grant_type_is_forbidden(self):
+        outcome = prepare_exchange(
+            {"grant_type": "client_credentials", "client_id": "myclientid"}, ENV
+        )
+        self.assertTrue(outcome.error)
+        self.assertEqual(outcome.status, 403)
+        self.assertEqual(outcome.body["error_description"], "Grant type not supported")
+
+
+class TestUtPrepareExchangeAuthorizationCode(unittest.TestCase):
+    def test_builds_forward_body_with_secret_and_code(self):
+        outcome = prepare_exchange(
+            {
+                "grant_type": "authorization_code",
+                "client_id": "myclientid",
+                "code": "AUTHCODE",
+                "code_verifier": "VERIFIER",
+                "redirect_uri": "http://127.0.0.1:8080/?oapp=github",
+            },
+            ENV,
+        )
+        self.assertFalse(outcome.error)
+        self.assertEqual(outcome.token_url, "https://example.test/oauth/token")
+        self.assertEqual(
+            outcome.body,
+            {
+                "client_secret": "mysecret",
+                "client_id": "myclientid",
+                "grant_type": "authorization_code",
+                "redirect_uri": "http://127.0.0.1:8080/?oapp=github",
+                "code": "AUTHCODE",
+                "code_verifier": "VERIFIER",
+            },
+        )
+
+    def test_client_secret_never_appears_in_a_client_supplied_field(self):
+        # The secret must come only from the environment, never be echoed
+        # back from anything the caller sent in the payload.
+        outcome = prepare_exchange(
+            {
+                "grant_type": "authorization_code",
+                "client_id": "myclientid",
+                "client_secret": "attacker-supplied",
+                "code": "AUTHCODE",
+            },
+            ENV,
+        )
+        self.assertEqual(outcome.body["client_secret"], "mysecret")
+
+
+class TestUtPrepareExchangeRefreshToken(unittest.TestCase):
+    def test_builds_forward_body_with_refresh_token(self):
+        outcome = prepare_exchange(
+            {
+                "grant_type": "refresh_token",
+                "client_id": "myclientid",
+                "refresh_token": "REFRESHTOKEN",
+                "redirect_uri": "http://127.0.0.1:8080/?oapp=github",
+            },
+            ENV,
+        )
+        self.assertFalse(outcome.error)
+        self.assertEqual(
+            outcome.body,
+            {
+                "client_secret": "mysecret",
+                "refresh_token": "REFRESHTOKEN",
+                "client_id": "myclientid",
+                "grant_type": "refresh_token",
+                "redirect_uri": "http://127.0.0.1:8080/?oapp=github",
+            },
+        )
+
+
+class TestUtLoadEnvFile(unittest.TestCase):
+    def test_parses_key_value_lines_and_skips_comments_and_blanks(self):
+        import tempfile
+        import os
+        from pathlib import Path
+
+        with tempfile.TemporaryDirectory() as tmp:
+            env_path = Path(tmp) / ".env"
+            env_path.write_text(
+                "# a comment\n"
+                "\n"
+                "CLIENT_SECRET_x=abc\n"
+                "TOKEN_URL_x=https://example.test/token\n"
+            )
+            marker = "CLIENT_SECRET_x"
+            os.environ.pop(marker, None)
+            try:
+                load_env_file(env_path)
+                self.assertEqual(os.environ.get("CLIENT_SECRET_x"), "abc")
+                self.assertEqual(os.environ.get("TOKEN_URL_x"), "https://example.test/token")
+            finally:
+                os.environ.pop("CLIENT_SECRET_x", None)
+                os.environ.pop("TOKEN_URL_x", None)
+
+    def test_does_not_override_an_already_set_shell_env_var(self):
+        import tempfile
+        import os
+        from pathlib import Path
+
+        with tempfile.TemporaryDirectory() as tmp:
+            env_path = Path(tmp) / ".env"
+            env_path.write_text("CLIENT_SECRET_x=from_dotenv\n")
+            os.environ["CLIENT_SECRET_x"] = "from_shell_or_secret_store"
+            try:
+                load_env_file(env_path)
+                self.assertEqual(os.environ["CLIENT_SECRET_x"], "from_shell_or_secret_store")
+            finally:
+                os.environ.pop("CLIENT_SECRET_x", None)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/dashgit-web/OAUTH2.md
+++ b/dashgit-web/OAUTH2.md
@@ -9,7 +9,7 @@ In simplified terms, this involves two phases:
 2. DashGit requests the *Authorization Server* to exchange the *Authorization code* for an *Access Token* that will be used by DashGit to authenticate all API calls until the session is closed (when the browser tab is closed).
 
 Out of the box, DashGit provides the necessary resources for the OAuth Authentication and Authorization process:
-- A predefined *GitHub OAuth App* and *GitLab Application* (hencefort, refered to as *App*) that play the role of *Client* in the OAuth2 protcol to manage all process.
+- A predefined *GitHub OAuth App* and *GitLab Application* (henceforth, referred to as *App*) that play the role of *Client* in the OAuth2 protcol to manage all process.
 - A *Exchange Proxy Service* to identify the *App* against the *Authorization Server* that prevents storing confidential information in the browser.
 
 Should you want to connect to an on-premises repository sever or customize the above, you may read the below sections.
@@ -33,17 +33,45 @@ This implies that you will be using your own resources for both the *App* and th
 - Create the *App* (GitHub OAuth App or GitLab Application) as indicated above:
   - On GitLab, ensure that *Confidential* is checked and take note of the *Secret* in addition to the *Application ID*
   - On GitHub, generate a new *Client secret* and take note of it in addition to the *Client ID*
-- Spin-up the *Exchange Proxy Service*:
-  - Folder `oauth-exchange` in this repo provides the source of a tiny *Exchange Proxy Service* docker container. The container must be started with a pair of environment variables for each *App* you are using, where `<CLIENT_ID>` is the identifier of the *App* obtained when it was created:
+- Spin-up the *Exchange Proxy Service*. There are two variants, described in the sections below: run it locally with `dashgit-server-py/server.py`, which also serves the web app, or deploy the `oauth-exchange` docker container. The configuration below applies to both:
+  - The service must be started with a pair of environment variables for each *App* you are using, where `<CLIENT_ID>` is the identifier of the *App* obtained when it was created:
     - `CLIENT_SECRET_<CLIENT_ID>`: Contains the secret required to identify the *App* against the *Authentication Server*.
     - `TOKEN_URL_<CLIENT_ID>` : The *Authentication Server* endpoint URL where the exchange request must be forwarded to.
   - The value of `TOKEN_URL_<CLIENT_ID>` must be:
     - On GitHub: `https://github.com/login/oauth/access_token`
     - On GitLab: `https://gitlab.com/oauth/token`
     - On GitLab (on-premises): `https://my-on-premises-gitlab-server/token`
-  - The container exposes a single resource `/exchange` that is used both to exchange the code for the token and to renew expired tokens.
-  - Build and run the container with the above environment variables.
-- In the DashGit OAuth2 custom configuration, in addition to the *OAuth App ID*:
-  - Set *OAuth exchange token URL* by adding `/exchange` resource to the container address.
-  - If for example, the container can be accessed to an address like `https://my-exchange-server`, the value of the *OAuth exchange token URL* will be `https://my-exchange-server/exchange`
+  - Either variant exposes a single resource `/exchange` that is used both to exchange the code for the token and to renew expired tokens.
+- In the DashGit OAuth2 custom configuration, in addition to the *OAuth App ID*, set *OAuth exchange token URL* by adding the `/exchange` resource to the address of the service. The sections below give the value for each variant.
 
+## Run everything locally
+
+`dashgit-server-py/server.py` serves the web app and the *Exchange Proxy Service* on a single port. It requires Python 3.7 or later and nothing else.
+```
+python3 dashgit-server-py/server.py        # serves DashGit at http://127.0.0.1:8080
+python3 dashgit-server-py/server.py 9000   # or choose another port
+```
+It binds to `127.0.0.1` and is not reachable from other machines in your network.
+
+This requires your own *App*, as the predefined one is registered against the public DashGit site and the *Authorization Server* will not redirect to any other address. Create it as described above, and then:
+- Set the callback URL that is requested when creating the *App* to the address of this server, instead of the address of a published site:
+  - On GitHub, set `http://127.0.0.1:8080/` as both the Homepage URL and the Authorization callback URL.
+  - On GitLab, set `http://127.0.0.1:8080/?oapp=gitlab` as the redirect URI.
+  - Then open DashGit in your browser at this very address. DashGit sends the address shown in the address bar, and the *Authorization Server* compares it to the one registered above: typing `localhost` when you registered `127.0.0.1` fails the login, even though both reach the same server. The examples use `127.0.0.1` because the OAuth2 specification recommends it over `localhost`.
+  - If you run the server on another port, replace `8080` accordingly, as the port is compared too.
+- Set the pair of environment variables described above (`CLIENT_SECRET_<CLIENT_ID>` and `TOKEN_URL_<CLIENT_ID>`), either:
+  - In a `.env` file located in the `dashgit-server-py` folder, see `.env.example` in that folder for the format, or
+  - In the shell environment. These take precedence over the values in `.env`, so that a wrapper script can obtain the secrets from a secret manager instead of storing them on disk.
+- Set *OAuth exchange token URL* to `http://127.0.0.1:8080/exchange`.
+
+The web app and the *Exchange Proxy Service* share the same origin here, so no CORS headers are needed or sent.
+
+## Run the Exchange Proxy Service separately
+
+Folder `oauth-exchange` in this repo provides the source of a small Docker container providing only the *Exchange Proxy Service*: the web app is served from somewhere else, either the public DashGit site or your own static hosting.
+
+- Build and run the container with the environment variables described above. It listens on port 3000, see the instructions at the end of `oauth-exchange/server.js` for the exact commands.
+- Set *OAuth exchange token URL* by adding the `/exchange` resource to the address where the container can be reached. For a container at `https://my-exchange-server`, the value is `https://my-exchan
+ge-server/exchange`.
+- Keep the callback URL of the *App* pointing to the address where the web app is served, as described above.
+- The web app and the container are on different origins, so the container allows cross origin requests.


### PR DESCRIPTION
- run.py (stdlib only) serves dashgit-web/app as static files and implements the oauth-exchange /exchange + /healthcheck endpoints on one port (default 8080).
- Exchange decision logic factored into prepare_exchange() so it can be unit tested without a live server; test_run.py covers it.
- CLIENT_SECRET_<id>/TOKEN_URL_<id> load from .env if present, but os.environ.setdefault() lets pre-exported shell vars (e.g. from a secret-manager wrapper) take precedence.