### PR TITLE
Combined dependency updates (2026-08-03)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,7 +84,7 @@ jobs:
       - if: github.event.pull_request.head.repo.fork
         name: Failing job that is executed from forked repo
         run: exit 1
-      - uses: javiertuya/sonarqube-action@v1.4.4
+      - uses: javiertuya/sonarqube-action@v1.4.5
         with: 
           github-token: ${{ secrets.GITHUB_TOKEN }}
           sonar-token: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -187,7 +187,7 @@ jobs:
           echo "gitlab.user=$USERNAME"                        >> dashgit-updater/it.properties
           echo "gitlab.email="                                >> dashgit-updater/it.properties
 
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v5.6.0
         with:
           distribution: 'temurin'
           java-version: '17'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Checkout GitHub repo
         uses: actions/checkout@v7
       - name: Use Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version-file: 'dashgit-web/test/.nvmrc'
           cache: 'npm'
@@ -55,7 +55,7 @@ jobs:
       - name: Checkout GitHub repo
         uses: actions/checkout@v7
       - name: Use Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version-file: 'dashgit-web/e2e/.nvmrc'
           cache: 'npm'

--- a/dashgit-updater/pom.xml
+++ b/dashgit-updater/pom.xml
@@ -77,7 +77,7 @@
 		<dependency>
 			<groupId>org.apache.httpcomponents.client5</groupId>
 			<artifactId>httpclient5</artifactId>
-			<version>5.6.2</version>
+			<version>5.6.3</version>
 		</dependency>
 
 		<dependency>
@@ -93,7 +93,7 @@
 		<dependency>
 			<groupId>org.eclipse.jgit</groupId>
 			<artifactId>org.eclipse.jgit</artifactId>
-			<version>7.7.0.202606012155-r</version>
+			<version>7.7.1.202607240634-r</version>
 		</dependency>
 
 	</dependencies>

--- a/dashgit-web/e2e/package-lock.json
+++ b/dashgit-web/e2e/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "dashgit-e2e",
       "devDependencies": {
-        "@playwright/test": "1.61.1",
+        "@playwright/test": "1.62.1",
         "http-server": "14.1.1"
       },
       "engines": {
@@ -14,19 +14,19 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.61.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
-      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.61.1"
+        "playwright": "1.62.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/ansi-styles": {
@@ -493,35 +493,35 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.61.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
-      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.61.1"
+        "playwright-core": "1.62.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.61.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
-      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/portfinder": {

--- a/dashgit-web/e2e/package.json
+++ b/dashgit-web/e2e/package.json
@@ -12,7 +12,7 @@
     "report": "playwright show-report"
   },
   "devDependencies": {
-    "@playwright/test": "1.61.1",
+    "@playwright/test": "1.62.1",
     "http-server": "14.1.1"
   }
 }

--- a/dashgit-web/test/package-lock.json
+++ b/dashgit-web/test/package-lock.json
@@ -9,7 +9,7 @@
         "chai": "6.2.2",
         "mocha": "11.7.6",
         "mochawesome": "7.1.4",
-        "sinon": "22.0.0"
+        "sinon": "22.1.0"
       },
       "engines": {
         "node": ">=24"
@@ -1116,9 +1116,9 @@
       }
     },
     "node_modules/sinon": {
-      "version": "22.0.0",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-22.0.0.tgz",
-      "integrity": "sha512-sq/6DpdXOrLyfbKlXLg/Usc7xu8YXPeLkOFZRvA3bNUSA2lhbrZ06yuXbH1fkzBPCbz9O10+7hznzUsjaYNm0Q==",
+      "version": "22.1.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-22.1.0.tgz",
+      "integrity": "sha512-n1ajF2rBWMTtEwbKcw4UdFg4nCnDdq/U6RDoxtOd7oapOlRoJ5ynwFx60owROyhDpA9QhMZi0pCO/xtmwFjG7w==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/dashgit-web/test/package-lock.json
+++ b/dashgit-web/test/package-lock.json
@@ -8,7 +8,7 @@
       "devDependencies": {
         "chai": "6.2.2",
         "mocha": "11.7.6",
-        "mochawesome": "7.1.4",
+        "mochawesome": "8.0.0",
         "sinon": "22.0.0"
       },
       "engines": {
@@ -679,31 +679,10 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/lodash.isempty": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
-      "integrity": "sha512-oKMuF3xEeqDltrGMfDxAPGIVMSSRv8tbRSODbrs4KGsRRLEhrW8N8Rd4DRgB2+621hY8A8XwwrTVhXWpxFvMzg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/lodash.isfunction": {
       "version": "3.0.9",
       "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz",
       "integrity": "sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash.isobject": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-3.0.2.tgz",
-      "integrity": "sha512-3/Qptq2vr7WeJbB4KHUSKlq8Pl7ASXi3UG6CMbBm8WRtXi8+GHm7mKaU3urfpSEzWe2wCIChs6/sdocUsTKJiA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash.isstring": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
       "dev": true,
       "license": "MIT"
     },
@@ -808,25 +787,21 @@
       }
     },
     "node_modules/mochawesome": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/mochawesome/-/mochawesome-7.1.4.tgz",
-      "integrity": "sha512-fucGSh8643QkSvNRFOaJ3+kfjF0FhA/YtvDncnRAG0A4oCtAzHIFkt/+SgsWil1uwoeT+Nu5fsAnrKkFtnPcZQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/mochawesome/-/mochawesome-8.0.0.tgz",
+      "integrity": "sha512-wVJiOHkMPirW1cBAzW98bWZk+97q7N28op3sw6AMLuxAKyisqOO2D6fnGFk1KJhvLK915u6TMFyl9Hnazj2XMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "chalk": "^4.1.2",
-        "diff": "^5.0.0",
+        "diff": "^5.2.0",
         "json-stringify-safe": "^5.0.1",
-        "lodash.isempty": "^4.4.0",
-        "lodash.isfunction": "^3.0.9",
-        "lodash.isobject": "^3.0.2",
-        "lodash.isstring": "^4.0.1",
-        "mochawesome-report-generator": "^6.3.0",
-        "strip-ansi": "^6.0.1",
-        "uuid": "^8.3.2"
+        "mochawesome-report-generator": "^6.3.2"
+      },
+      "engines": {
+        "node": ">=22"
       },
       "peerDependencies": {
-        "mocha": ">=7"
+        "mocha": ">=8"
       }
     },
     "node_modules/mochawesome-report-generator": {
@@ -852,16 +827,6 @@
         "marge": "bin/cli.js"
       }
     },
-    "node_modules/mochawesome/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/mochawesome/node_modules/diff": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
@@ -870,19 +835,6 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
-      }
-    },
-    "node_modules/mochawesome/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/ms": {
@@ -1310,17 +1262,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/which": {

--- a/dashgit-web/test/package.json
+++ b/dashgit-web/test/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "mocha": "11.7.6",
-    "sinon": "22.0.0",
+    "sinon": "22.1.0",
     "chai": "6.2.2",
     "mochawesome": "7.1.4"
   }

--- a/dashgit-web/test/package.json
+++ b/dashgit-web/test/package.json
@@ -15,6 +15,6 @@
     "mocha": "11.7.6",
     "sinon": "22.0.0",
     "chai": "6.2.2",
-    "mochawesome": "7.1.4"
+    "mochawesome": "8.0.0"
   }
 }


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump the maven-updates group in /dashgit-updater with 2 updates](https://github.com/javiertuya/dashgit/pull/327)
- [Bump actions/setup-java from 5 to 5.6.0](https://github.com/javiertuya/dashgit/pull/330)
- [Bump mochawesome from 7.1.4 to 8.0.0 in /dashgit-web/test](https://github.com/javiertuya/dashgit/pull/329)
- [Bump @playwright/test from 1.61.1 to 1.62.1 in /dashgit-web/e2e](https://github.com/javiertuya/dashgit/pull/328)
- [Bump sinon from 22.0.0 to 22.1.0 in /dashgit-web/test](https://github.com/javiertuya/dashgit/pull/321)
- [Bump actions/setup-node from 6 to 7](https://github.com/javiertuya/dashgit/pull/319)
- [Bump javiertuya/sonarqube-action from 1.4.4 to 1.4.5](https://github.com/javiertuya/dashgit/pull/320)