### PR TITLE
ci: run sonarqube after the test jobs and skip it on forks and dashgit branches

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,14 +80,15 @@ jobs:
             dashgit-web/e2e/screenshots
 
   sonarqube:
-    # As in test-ut, but excludes dependabot updates to remove duplicates on local prs
+    needs: [test-ut, test-e2e]
     #if: ${{ false }}
-    if: github.actor != 'dependabot[bot]' && ( (github.event_name != 'pull_request' && ! github.event.pull_request.head.repo.fork) || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.fork || startsWith(github.head_ref, 'dependabot/'))) )
+    # This job fails when comming from a dependabot PR or a forked repo
+    # (can't read the sonarqube token for security reasons).
+    # Also skipped on the branches merged by dashgit, that only contain version updates
+    if: ${{ github.actor != 'dependabot[bot]' && !github.event.pull_request.head.repo.fork
+      && !startsWith(github.ref, 'refs/heads/dashgit/combined/') }}
     runs-on: ubuntu-latest
     steps:
-      - if: github.event.pull_request.head.repo.fork
-        name: Failing job that is executed from forked repo
-        run: exit 1
       - uses: javiertuya/sonarqube-action@v1.4.5
         with: 
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Aligns this repo with the guard used in the rest of the repositories: sonarqube
runs after the tests and is skipped where it cannot work or adds no value.

- add needs on test-ut and test-e2e
- replace the copy of the test guard: skip forked-repo PRs, dependabot and the
  dashgit/combined/** branches (only version bumps)
- remove the step that failed on purpose when coming from a fork, unreachable
  now that the whole job is skipped there

🤖 Generated with [Claude Code](https://claude.com/claude-code)
