### PR TITLE
ci: analyze the python server with sonar

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,7 +95,7 @@ jobs:
             dashgit-web/e2e/screenshots
 
   sonarqube:
-    needs: [test-ut, test-e2e]
+    needs: [test-ut, test-ut-server-py, test-e2e]
     #if: ${{ false }}
     # This job fails when comming from a dependabot PR or a forked repo
     # (can't read the sonarqube token for security reasons).

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -7,6 +7,8 @@ sonar.sourceEncoding=UTF-8
 # dashgit-server-py: only server.py, test_server.py is left out as any other test source
 sonar.sources=dashgit-web/app,dashgit-updater/src/main/java,dashgit-server-py/server.py
 sonar.java.source=17
+# The minimum version documented in server.py, CI only runs the latest 3.x
+sonar.python.version=3.7
 sonar.java.binaries=dashgit-updater/target/classes
 # May 2024 A sonarcloud update added some rules that recommend a markup
 # that is different from the bootstrap markup used in the nav-item elements, add exclusions

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,7 +4,8 @@ sonar.projectName=dashgit
 sonar.projectVersion=2.0
 sonar.sourceEncoding=UTF-8
 # Uses an action targetted to java, paths to js are relative to the java projects
-sonar.sources=dashgit-web/app,dashgit-updater/src/main/java
+# dashgit-server-py: only server.py, test_server.py is left out as any other test source
+sonar.sources=dashgit-web/app,dashgit-updater/src/main/java,dashgit-server-py/server.py
 sonar.java.source=17
 sonar.java.binaries=dashgit-updater/target/classes
 # May 2024 A sonarcloud update added some rules that recommend a markup


### PR DESCRIPTION
The local Python server added in #326 was not covered by the static analysis.

- Add `dashgit-server-py/server.py` to `sonar.sources`
- Set `sonar.python.version=3.7`, the minimum version documented in `server.py`
- Make the `sonarqube` job depend on `test-ut-server-py`

## Notes

Only `server.py` is listed, not the whole folder, so that `test_server.py` stays out of the analysed sources (as with the Java project, where only `src/main/java` is declared).

The CI job runs `python-version: '3.x'`, so nothing verifies the documented 3.7 floor at runtime, and 3.7 is EOL and no longer available on `ubuntu-latest`. Declaring the version to Sonar is the only check on that claim. As a side effect the analysis also gets more precise: without the property the analyser assumes the code targets both Python 2 and 3, which silences rules to avoid false positives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
