### PR TITLE
fix: clear the sonarqube issues reported on the python server

### DIFF
--- a/dashgit-server-py/server.py
+++ b/dashgit-server-py/server.py
@@ -22,6 +22,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent
 WEB_APP_DIR = ROOT.parent / "dashgit-web" / "app"
 ENV_FILE = ROOT / ".env"
+CONTENT_TYPE_JSON = "application/json"
 VERBOSE = False
 
 
@@ -134,7 +135,7 @@ class Handler(SimpleHTTPRequestHandler):
         req = urllib.request.Request(
             outcome.token_url,
             data=json.dumps(outcome.body).encode(),
-            headers={"Content-Type": "application/json", "Accept": "application/json"},
+            headers={"Content-Type": CONTENT_TYPE_JSON, "Accept": CONTENT_TYPE_JSON},
             method="POST",
         )
         try:
@@ -148,14 +149,14 @@ class Handler(SimpleHTTPRequestHandler):
             return
 
         self.send_response(200)
-        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Type", CONTENT_TYPE_JSON)
         self.end_headers()
         self.wfile.write(data)
 
     # No CORS headers added as the app and /exchange are served from this same origin. 
     def _send_json(self, status, body, as_json=True):
         self.send_response(status)
-        self.send_header("Content-Type", "application/json" if as_json else "text/plain")
+        self.send_header("Content-Type", CONTENT_TYPE_JSON if as_json else "text/plain")
         self.end_headers()
         self.wfile.write((json.dumps(body) if as_json else body).encode())
 
@@ -185,7 +186,9 @@ def main():
     server = ThreadingHTTPServer(("127.0.0.1", port), Handler)
     print(f"DashGit running at http://127.0.0.1:{port}  (serving {WEB_APP_DIR}, exchange proxy at /exchange)")
     try:
-        server.serve_forever()
+        # Plain HTTP is intended: this is a local runner bound to 127.0.0.1,
+        # TLS would only add certificate handling with nothing to protect on the loopback
+        server.serve_forever()  # NOSONAR
     except KeyboardInterrupt:
         pass
 

--- a/dashgit-server-py/server.py
+++ b/dashgit-server-py/server.py
@@ -22,6 +22,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent
 WEB_APP_DIR = ROOT.parent / "dashgit-web" / "app"
 ENV_FILE = ROOT / ".env"
+HEADER_CONTENT_TYPE = "Content-Type"
 CONTENT_TYPE_JSON = "application/json"
 VERBOSE = False
 
@@ -135,7 +136,7 @@ class Handler(SimpleHTTPRequestHandler):
         req = urllib.request.Request(
             outcome.token_url,
             data=json.dumps(outcome.body).encode(),
-            headers={"Content-Type": CONTENT_TYPE_JSON, "Accept": CONTENT_TYPE_JSON},
+            headers={HEADER_CONTENT_TYPE: CONTENT_TYPE_JSON, "Accept": CONTENT_TYPE_JSON},
             method="POST",
         )
         try:
@@ -149,14 +150,14 @@ class Handler(SimpleHTTPRequestHandler):
             return
 
         self.send_response(200)
-        self.send_header("Content-Type", CONTENT_TYPE_JSON)
+        self.send_header(HEADER_CONTENT_TYPE, CONTENT_TYPE_JSON)
         self.end_headers()
         self.wfile.write(data)
 
     # No CORS headers added as the app and /exchange are served from this same origin. 
     def _send_json(self, status, body, as_json=True):
         self.send_response(status)
-        self.send_header("Content-Type", CONTENT_TYPE_JSON if as_json else "text/plain")
+        self.send_header(HEADER_CONTENT_TYPE, CONTENT_TYPE_JSON if as_json else "text/plain")
         self.end_headers()
         self.wfile.write((json.dumps(body) if as_json else body).encode())
 


### PR DESCRIPTION
Adding `server.py` to the analysis in #336 surfaced two issues on `main`.

- `python:S1192`: extract a `CONTENT_TYPE_JSON` constant for the `"application/json"` literal, repeated 4 times, and a `HEADER_CONTENT_TYPE` one for the header name
- `python:S5332`: silence the clear-text protocol warning with `# NOSONAR`, as serving plain HTTP is the intent here

## Notes

S5332 does not point at a URL literal but at the `serve_forever()` call: the rule flags any HTTP server without TLS. The server binds to `127.0.0.1` and only serves the local user, so TLS would add certificate handling with nothing to protect.

`"Content-Type"` appears 3 times and was not reported, so the S1192 threshold in the quality profile looks to be 4 rather than the default 3. It is extracted anyway for consistency with the value constant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
