### PR TITLE
Combined dependency updates (2026-09-02)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -218,7 +218,7 @@ jobs:
 
       - name: Generate report checks - ${{ matrix.scope }}
         if: success() || failure()
-        uses: mikepenz/action-junit-report@v6.4.2
+        uses: mikepenz/action-junit-report@v6.5.0
         with:
           check_name: "test-it-result-${{ matrix.scope }}"
           report_paths: "**/surefire-reports/TEST-*.xml"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Checkout GitHub repo
         uses: actions/checkout@v7
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '3.x'
       - name: Run unit tests for server.py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -203,7 +203,7 @@ jobs:
           echo "gitlab.user=$USERNAME"                        >> dashgit-updater/it.properties
           echo "gitlab.email="                                >> dashgit-updater/it.properties
 
-      - uses: actions/setup-java@v5.6.0
+      - uses: actions/setup-java@v6.0.0
         with:
           distribution: 'temurin'
           java-version: '17'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -146,7 +146,7 @@ jobs:
     steps:
     - uses: actions/checkout@v7
     - run: echo "current branch ${{ github.ref_name }}"
-    - uses: dorny/paths-filter@v4.0.2
+    - uses: dorny/paths-filter@v4.0.3
       id: filter
       with:
         base: ${{ github.ref_name }}

--- a/dashgit-updater/pom.xml
+++ b/dashgit-updater/pom.xml
@@ -72,12 +72,12 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-web</artifactId>
-			<version>7.0.8</version>
+			<version>7.0.9</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.httpcomponents.client5</groupId>
 			<artifactId>httpclient5</artifactId>
-			<version>5.6.3</version>
+			<version>5.6.4</version>
 		</dependency>
 
 		<dependency>

--- a/dashgit-web/app/index.html
+++ b/dashgit-web/app/index.html
@@ -15,7 +15,7 @@
     {
       "imports": {
         "octokit/rest" : "https://esm.sh/@octokit/rest@22.0.1",
-        "octokit/graphql" : "https://esm.sh/@octokit/graphql@9.0.3",
+        "octokit/graphql" : "https://esm.sh/@octokit/graphql@9.0.4",
         "gitbeaker/rest": "https://esm.sh/@gitbeaker/rest@43.8.0"
       }
     }

--- a/dashgit-web/app/package.json
+++ b/dashgit-web/app/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "dependencies": {
     "@octokit/rest": "22.0.1",
-    "@octokit/graphql": "9.0.3",
+    "@octokit/graphql": "9.0.4",
     "@gitbeaker/rest": "43.8.0"
   }
 }

--- a/dashgit-web/test/package-lock.json
+++ b/dashgit-web/test/package-lock.json
@@ -621,9 +621,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {

--- a/dashgit-web/test/package-lock.json
+++ b/dashgit-web/test/package-lock.json
@@ -7,7 +7,7 @@
       "name": "dashgit-test",
       "devDependencies": {
         "chai": "6.2.2",
-        "mocha": "11.7.6",
+        "mocha": "11.8.0",
         "mochawesome": "8.0.0",
         "sinon": "22.1.0"
       },
@@ -750,9 +750,9 @@
       }
     },
     "node_modules/mocha": {
-      "version": "11.7.6",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.6.tgz",
-      "integrity": "sha512-nS9xOGbw2I3cjCpxwZAEJ9xK9lmJ08vEkQvLtz4du9ZrF9UrjRpeJGiIgl2Z+Qs++pmB4ecDe48Fwsh+j+j7xA==",
+      "version": "11.8.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.8.0.tgz",
+      "integrity": "sha512-VyCeUdGN3A9lmCTTgG4yuvY9ixxaDk+xt2R/7/+1AP6EqNG+G9OKkzBwhVtVYoNX8YsxNSgAl8mOv3IAeOpFbw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/dashgit-web/test/package-lock.json
+++ b/dashgit-web/test/package-lock.json
@@ -8,7 +8,7 @@
       "devDependencies": {
         "chai": "6.2.2",
         "mocha": "11.7.6",
-        "mochawesome": "8.0.0",
+        "mochawesome": "8.0.1",
         "sinon": "22.1.0"
       },
       "engines": {
@@ -787,9 +787,9 @@
       }
     },
     "node_modules/mochawesome": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/mochawesome/-/mochawesome-8.0.0.tgz",
-      "integrity": "sha512-wVJiOHkMPirW1cBAzW98bWZk+97q7N28op3sw6AMLuxAKyisqOO2D6fnGFk1KJhvLK915u6TMFyl9Hnazj2XMQ==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/mochawesome/-/mochawesome-8.0.1.tgz",
+      "integrity": "sha512-td4a9zw4KmPH6Z/IjA1JljEH4Ves860n8+xm35JfVmqqeHLvDpnU8WK9XSUCFZiY/lB+4wBdAMojiHexqvLtSQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/dashgit-web/test/package.json
+++ b/dashgit-web/test/package.json
@@ -12,7 +12,7 @@
     "report": "mocha Test*.js --reporter mochawesome"
   },
   "devDependencies": {
-    "mocha": "11.7.6",
+    "mocha": "11.8.0",
     "sinon": "22.1.0",
     "chai": "6.2.2",
     "mochawesome": "8.0.0"

--- a/dashgit-web/test/package.json
+++ b/dashgit-web/test/package.json
@@ -15,6 +15,6 @@
     "mocha": "11.7.6",
     "sinon": "22.1.0",
     "chai": "6.2.2",
-    "mochawesome": "8.0.0"
+    "mochawesome": "8.0.1"
   }
 }


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump the maven-updates group in /dashgit-updater with 2 updates](https://github.com/javiertuya/dashgit/pull/347)
- [Bump @octokit/graphql from 9.0.3 to 9.0.4 in /dashgit-web/app in the web-manual-updates group](https://github.com/javiertuya/dashgit/pull/338)
- [Bump mikepenz/action-junit-report from 6.4.2 to 6.5.0](https://github.com/javiertuya/dashgit/pull/346)
- [Bump actions/setup-java from 5.6.0 to 6.0.0](https://github.com/javiertuya/dashgit/pull/344)
- [Bump dorny/paths-filter from 4.0.2 to 4.0.3](https://github.com/javiertuya/dashgit/pull/343)
- [Bump js-yaml from 4.3.0 to 4.3.1 in /dashgit-web/test](https://github.com/javiertuya/dashgit/pull/334)
- [Bump mochawesome from 8.0.0 to 8.0.1 in /dashgit-web/test](https://github.com/javiertuya/dashgit/pull/342)
- [Bump mocha from 11.7.6 to 11.8.0 in /dashgit-web/test](https://github.com/javiertuya/dashgit/pull/341)
- [Bump actions/setup-python from 6 to 7](https://github.com/javiertuya/dashgit/pull/340)