### PR TITLE
fix: count team_mention as a mention in the Involved tab

### DIFF
--- a/dashgit-web/app/WiController.js
+++ b/dashgit-web/app/WiController.js
@@ -358,8 +358,8 @@ const wiController = {
     let mentionCount = 0;
     for (let notifKey in notifCache.data[prop]) {
       let reason = notifCache.data[prop][notifKey];
-      if (reason == "mention" || reason == "mentioned" || reason == "directly_addressed")
-        mentionCount++; //PENDING: reason values are duplicated in the view, refactor
+      if (notifCache.isMention(reason))
+        mentionCount++;
     }
     return mentionCount;
   },

--- a/dashgit-web/app/WiViewRender.js
+++ b/dashgit-web/app/WiViewRender.js
@@ -74,7 +74,7 @@ const wiRender = {
     let reason = notifCache.getModel(provider)[uid];
     if (reason == undefined)
       return "";
-    let iconClass = reason == "mention" || reason == "mentioned" || reason == "directly_addressed" ? this.mentionIconClass : this.notificationIconClass;
+    let iconClass = notifCache.isMention(reason) ? this.mentionIconClass : this.notificationIconClass;
     return `<i class="wi-notification-icon ${iconClass}" title="Unread notification, reason: ${reason}"></i>`;
   },
 

--- a/dashgit-web/app/core/NotifCache.js
+++ b/dashgit-web/app/core/NotifCache.js
@@ -17,6 +17,13 @@ const notifCache = {
       items[mod.getModelUid(notif[i].repo_name, notif[i].type, notif[i].iid, "")] = notif[i].reason; //do not collect from branches
     this.data[provider] = items; //replace content
   },
+  //Notification reasons that are considered a mention of the user.
+  //GitHub: mention (directly mentioned), team_mention (mentioned through a team the user belongs to).
+  //GitLab: mentioned (name at the end), directly_addressed (name at the beginning)
+  mentionReasons: ["mention", "team_mention", "mentioned", "directly_addressed"],
+  isMention: function (reason) {
+    return this.mentionReasons.includes(reason);
+  },
   getModel: function (provider) {
     if (surrogates.hasSurrogate(provider)) {
       let origin = surrogates.getSurrogate(provider);

--- a/dashgit-web/test/TestWiViewRender.js
+++ b/dashgit-web/test/TestWiViewRender.js
@@ -1,5 +1,6 @@
 import assert from 'assert';
 import { wiRender } from '../app/WiViewRender.js'
+import { notifCache } from '../app/core/NotifCache.js'
 
 describe('TestWiViewRender - Label rendering', function () {
   it('renders issue type labels with named colors without invalid # prefix', function () {
@@ -67,5 +68,37 @@ describe('TestWiViewRender - Label rendering', function () {
     assert.ok(html.includes('pending merge'));
     assert.ok(!html.includes('review request'));
     assert.ok(!html.includes('in review'));
+  });
+});
+
+describe('TestWiViewRender - Notification rendering', function () {
+  const uid = 'giis-uniovi-test-update_issue_1';
+  afterEach(function () {
+    notifCache.reset();
+  });
+  function renderReason(reason) {
+    notifCache.data['gh1'] = { [uid]: reason };
+    return wiRender.notifications2html('gh1', uid);
+  }
+
+  it('renders the mention icon for each reason that mentions the user', function () {
+    for (const reason of ['mention', 'team_mention', 'mentioned', 'directly_addressed']) {
+      assert.ok(notifCache.isMention(reason), `${reason} must be a mention`);
+      assert.ok(renderReason(reason).includes(wiRender.mentionIconClass), `${reason} must render the mention icon`);
+    }
+  });
+
+  it('renders the bell icon for reasons that do not mention the user', function () {
+    for (const reason of ['subscribed', 'assign', 'author', 'state_change']) {
+      assert.ok(!notifCache.isMention(reason), `${reason} must not be a mention`);
+      assert.ok(renderReason(reason).includes(wiRender.notificationIconClass), `${reason} must render the bell icon`);
+    }
+  });
+
+  it('renders nothing when there is no notification for the work item', function () {
+    notifCache.data['gh1'] = {};
+    assert.strictEqual(wiRender.notifications2html('gh1', uid), '');
+    notifCache.reset();
+    assert.strictEqual(wiRender.notifications2html('gh1', uid), '');
   });
 });


### PR DESCRIPTION
GitHub notifications with reason `team_mention` were treated as plain notifications, so they were neither counted in the Involved tab mention badge nor rendered with the mention icon.

- Move the set of mention reasons to a single `isMention()` helper in the notifications cache, used by both the counter and the icon rendering, which removes the duplication flagged as pending in the counter
- Add `team_mention` to that set
- Cover the mention and non-mention reasons with unit tests

Closes #355

## Notes

The unit test was checked against the unfixed code: removing `team_mention` from the set makes it fail. The GitLab reasons (`mentioned`, `directly_addressed`) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)